### PR TITLE
NiFpga Support

### DIFF
--- a/aoldaq/CMakeLists.txt
+++ b/aoldaq/CMakeLists.txt
@@ -42,7 +42,7 @@ IF(UNIX AND NOT APPLE)
     SET_TARGET_PROPERTIES(aoldaq PROPERTIES COMPILE_OPTIONS "-pthread")
     SET_TARGET_PROPERTIES(aoldaq PROPERTIES INTERFACE_COMPILE_OPTIONS "-pthread")
     
-    TARGET_LINK_LIBRARIES(aoldaq pthread)
+    TARGET_LINK_LIBRARIES(aoldaq pthread -ldl)
 
     TARGET_SOURCES(aoldaq PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/os_pipe_unix.c)
 
@@ -50,7 +50,7 @@ IF(UNIX AND NOT APPLE)
     SET_TARGET_PROPERTIES(aoldaq_static PROPERTIES COMPILE_OPTIONS "-pthread")
     SET_TARGET_PROPERTIES(aoldaq_static PROPERTIES INTERFACE_COMPILE_OPTIONS "-pthread")
     
-    TARGET_LINK_LIBRARIES(aoldaq_static pthread)
+    TARGET_LINK_LIBRARIES(aoldaq_static pthread -ldl)
 
     TARGET_SOURCES(aoldaq_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/os_pipe_unix.c)
 ELSEIF(WIN32)

--- a/aoldaq/CMakeLists.txt
+++ b/aoldaq/CMakeLists.txt
@@ -71,6 +71,18 @@ ENDIF(UNIX AND NOT APPLE)
 # Win32 is picky...
 ADD_DEFINITIONS(-DAOL_BUILD)
 
+# Do we want to compile with support for the real FPGA?
+OPTION(AOL_USE_NIFPGA "Set this to ON to compile with support for the real acquisition FPGA." OFF)
+
+IF(AOL_USE_NIFPGA)
+    MESSAGE("Building using the real NiFpga interface.")
+    # Add our compile flag
+    ADD_DEFINITIONS(-DAOL_USE_NIFPGA)
+    # ...and add that ugly generated file
+    TARGET_SOURCES(aoldaq PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/NiFpga.c)
+    TARGET_SOURCES(aoldaq_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/NiFpga.c)
+ENDIF(AOL_USE_NIFPGA)
+
 # Add the headers
 TARGET_INCLUDE_DIRECTORIES(aoldaq PUBLIC ./include)
 TARGET_INCLUDE_DIRECTORIES(aoldaq PRIVATE ./external/include)

--- a/aoldaq/include/aoldaq/aoldaq.h
+++ b/aoldaq/include/aoldaq/aoldaq.h
@@ -70,6 +70,17 @@ typedef struct {
 
     /// The height of the image. Only for bitmap mode.
     uint32_t bitmap_height;
+
+#ifdef AOL_USE_NIFPGA
+    /// The acquisition FPGA bitfile.
+    const char *nifpga_bitfile;
+
+    /// The signature for the acquisition FPGA.
+    const char *nifpga_signature;
+
+    /// The target resource for the acquisition FPGA.
+    const char *nifpga_resource;
+#endif
 } aoldaq_args_t;
 
 /// This struct holds a single ramp
@@ -116,10 +127,20 @@ AOL_DLL extern uint32_t aoldaq_get_ramps(aoldaq_t *p_state, uint32_t n_cycles, r
 /// Returns the number of voxels read.
 AOL_DLL extern uint32_t aoldaq_get_voxels(aoldaq_t *p_state, uint8_t channel, uint32_t *buf, uint32_t n_voxels);
 
+#ifdef AOL_USE_NIFPGA
 /// Gets the NiFpga session object from the underlying FPGA
 /// object. This is used to setup the physical acquisition FPGA
 /// through Matlab. Once we deal with the initialization ourselves, 
 /// this function will removed.
 AOL_DLL extern uint32_t aoldaq_get_nifpga_session(aoldaq_t *p_state);
+
+/// Sets the initalized flag in the underlying FPGA object to true. 
+/// This will be mostly be called after Matlab has finished the 
+/// physical FPGA initialization.
+AOL_DLL extern void aoldaq_flag_nifpga_initialized(aoldaq_t *p_state);
+
+/// Sets the initalized flag in the underlying FPGA object to false. 
+AOL_DLL extern void aoldaq_flag_nifpga_not_initialized(aoldaq_t *p_state);
+#endif
 
 #endif 

--- a/aoldaq/include/aoldaq/aoldaq.h
+++ b/aoldaq/include/aoldaq/aoldaq.h
@@ -116,4 +116,10 @@ AOL_DLL extern uint32_t aoldaq_get_ramps(aoldaq_t *p_state, uint32_t n_cycles, r
 /// Returns the number of voxels read.
 AOL_DLL extern uint32_t aoldaq_get_voxels(aoldaq_t *p_state, uint8_t channel, uint32_t *buf, uint32_t n_voxels);
 
+/// Gets the NiFpga session object from the underlying FPGA
+/// object. This is used to setup the physical acquisition FPGA
+/// through Matlab. Once we deal with the initialization ourselves, 
+/// this function will removed.
+AOL_DLL extern uint32_t aoldaq_get_nifpga_session(aoldaq_t *p_state);
+
 #endif 

--- a/aoldaq/src/NiFpga.c
+++ b/aoldaq/src/NiFpga.c
@@ -1,0 +1,2479 @@
+/*
+ * FPGA Interface C API 17.0 source file.
+ *
+ * Copyright (c) 2017,
+ * National Instruments Corporation.
+ * All rights reserved.
+ */
+
+#include "NiFpga.h"
+
+/*
+ * Platform specific includes.
+ */
+#if NiFpga_Windows
+   #include <windows.h>
+#elif NiFpga_VxWorks
+   #include <vxWorks.h>
+   #include <symLib.h>
+   #include <loadLib.h>
+   #include <sysSymTbl.h>
+   MODULE_ID VxLoadLibraryFromPath(const char* path, int flags);
+   STATUS VxFreeLibrary(MODULE_ID library, int flags);
+#elif NiFpga_Linux || NiFpga_MacOsX
+   #include <stdlib.h>
+   #include <stdio.h>
+   #include <dlfcn.h>
+#else
+   #error
+#endif
+
+/*
+ * Platform specific defines.
+ */
+#if NiFpga_Windows
+   #define NiFpga_CCall   __cdecl
+   #define NiFpga_StdCall __stdcall
+#else
+   #define NiFpga_CCall
+   #define NiFpga_StdCall
+#endif
+
+/*
+ * Global library handle, or NULL if the library isn't loaded.
+ */
+#if NiFpga_Windows
+   static HMODULE NiFpga_library = NULL;
+#elif NiFpga_VxWorks
+   static MODULE_ID NiFpga_library = NULL;
+#elif NiFpga_Linux || NiFpga_MacOsX
+   static void* NiFpga_library = NULL;
+#else
+   #error
+#endif
+
+/*
+ * CVI Resource Tracking functions.
+ */
+#if NiFpga_Cvi && NiFpga_Windows
+#define NiFpga_CviResourceTracking 1
+
+static char* const NiFpga_cviResourceType = "FPGA Interface C API";
+
+typedef void* (NiFpga_CCall *NiFpga_AcquireCviResource)(void* resource,
+                                                        char* type,
+                                                        char* description,
+                                                        ...);
+
+static NiFpga_AcquireCviResource NiFpga_acquireCviResource = NULL;
+
+typedef void* (NiFpga_StdCall *NiFpga_ReleaseCviResource)(void* resource);
+
+static NiFpga_ReleaseCviResource NiFpga_releaseCviResource = NULL;
+#endif
+
+/*
+ * Session management functions.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_open)(
+                          const char*     path,
+                          const char*     signature,
+                          const char*     resource,
+                          uint32_t        attribute,
+                          NiFpga_Session* session) = NULL;
+
+NiFpga_Status NiFpga_Open(const char*     path,
+                          const char*     signature,
+                          const char*     resource,
+                          uint32_t        attribute,
+                          NiFpga_Session* session)
+{
+   const NiFpga_Status result = NiFpga_open
+                              ? NiFpga_open(path,
+                                            signature,
+                                            resource,
+                                            attribute,
+                                            session)
+                              : NiFpga_Status_ResourceNotInitialized;
+   #if NiFpga_CviResourceTracking
+      if (NiFpga_acquireCviResource
+      &&  NiFpga_IsNotError(result))
+         NiFpga_acquireCviResource((void*)*session,
+                                   NiFpga_cviResourceType,
+                                   "NiFpga_Session %#08x",
+                                   *session);
+   #endif
+   return result;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_close)(
+                           NiFpga_Session session,
+                           uint32_t       attribute) = NULL;
+
+NiFpga_Status NiFpga_Close(NiFpga_Session session,
+                           uint32_t       attribute)
+{
+   if (!NiFpga_close)
+      return NiFpga_Status_ResourceNotInitialized;
+   #if NiFpga_CviResourceTracking
+      if (NiFpga_releaseCviResource)
+         NiFpga_releaseCviResource((void*)session);
+   #endif
+   return NiFpga_close(session, attribute);
+}
+
+/*
+ * FPGA state functions.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_run)(
+                         NiFpga_Session session,
+                         uint32_t       attribute) = NULL;
+
+NiFpga_Status NiFpga_Run(NiFpga_Session session,
+                         uint32_t       attribute)
+{
+   return NiFpga_run
+        ? NiFpga_run(session, attribute)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_abort)(
+                           NiFpga_Session session) = NULL;
+
+NiFpga_Status NiFpga_Abort(NiFpga_Session session)
+{
+   return NiFpga_abort
+        ? NiFpga_abort(session)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_reset)(
+                           NiFpga_Session session) = NULL;
+
+NiFpga_Status NiFpga_Reset(NiFpga_Session session)
+{
+   return NiFpga_reset
+        ? NiFpga_reset(session)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_download)(
+                              NiFpga_Session session) = NULL;
+
+NiFpga_Status NiFpga_Download(NiFpga_Session session)
+{
+   return NiFpga_download
+        ? NiFpga_download(session)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/*
+ * Functions to read from scalar indicators and controls.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_readBool)(
+                              NiFpga_Session session,
+                              uint32_t       indicator,
+                              NiFpga_Bool*   value) = NULL;
+
+NiFpga_Status NiFpga_ReadBool(NiFpga_Session session,
+                              uint32_t       indicator,
+                              NiFpga_Bool*   value)
+{
+   return NiFpga_readBool
+        ? NiFpga_readBool(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readI8)(
+                            NiFpga_Session session,
+                            uint32_t       indicator,
+                            int8_t*        value) = NULL;
+
+NiFpga_Status NiFpga_ReadI8(NiFpga_Session session,
+                            uint32_t       indicator,
+                            int8_t*        value)
+{
+   return NiFpga_readI8
+        ? NiFpga_readI8(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readU8)(
+                            NiFpga_Session session,
+                            uint32_t       indicator,
+                            uint8_t*       value) = NULL;
+
+NiFpga_Status NiFpga_ReadU8(NiFpga_Session session,
+                            uint32_t       indicator,
+                            uint8_t*       value)
+{
+   return NiFpga_readU8
+        ? NiFpga_readU8(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readI16)(
+                             NiFpga_Session session,
+                             uint32_t       indicator,
+                             int16_t*       value) = NULL;
+
+NiFpga_Status NiFpga_ReadI16(NiFpga_Session session,
+                             uint32_t       indicator,
+                             int16_t*       value)
+{
+   return NiFpga_readI16
+        ? NiFpga_readI16(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readU16)(
+                             NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint16_t*      value) = NULL;
+
+NiFpga_Status NiFpga_ReadU16(NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint16_t*      value)
+{
+   return NiFpga_readU16
+        ? NiFpga_readU16(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readI32)(
+                             NiFpga_Session session,
+                             uint32_t       indicator,
+                             int32_t*       value) = NULL;
+
+NiFpga_Status NiFpga_ReadI32(NiFpga_Session session,
+                             uint32_t       indicator,
+                             int32_t*       value)
+{
+   return NiFpga_readI32
+        ? NiFpga_readI32(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readU32)(
+                             NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint32_t*      value) = NULL;
+
+NiFpga_Status NiFpga_ReadU32(NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint32_t*      value)
+{
+   return NiFpga_readU32
+        ? NiFpga_readU32(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readI64)(
+                             NiFpga_Session session,
+                             uint32_t       indicator,
+                             int64_t*       value) = NULL;
+
+NiFpga_Status NiFpga_ReadI64(NiFpga_Session session,
+                             uint32_t       indicator,
+                             int64_t*       value)
+{
+   return NiFpga_readI64
+        ? NiFpga_readI64(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readU64)(
+                             NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint64_t*      value) = NULL;
+
+NiFpga_Status NiFpga_ReadU64(NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint64_t*      value)
+{
+   return NiFpga_readU64
+        ? NiFpga_readU64(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readSgl)(
+                             NiFpga_Session session,
+                             uint32_t       indicator,
+                             float*         value) = NULL;
+
+NiFpga_Status NiFpga_ReadSgl(NiFpga_Session session,
+                             uint32_t       indicator,
+                             float*         value)
+{
+   return NiFpga_readSgl
+        ? NiFpga_readSgl(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readDbl)(
+                             NiFpga_Session session,
+                             uint32_t       indicator,
+                             double*        value) = NULL;
+
+NiFpga_Status NiFpga_ReadDbl(NiFpga_Session session,
+                             uint32_t       indicator,
+                             double*        value)
+{
+   return NiFpga_readDbl
+        ? NiFpga_readDbl(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/*
+ * Functions to write to scalar controls and indicators.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeBool)(
+                               NiFpga_Session session,
+                               uint32_t       control,
+                               NiFpga_Bool    value) = NULL;
+
+NiFpga_Status NiFpga_WriteBool(NiFpga_Session session,
+                               uint32_t       control,
+                               NiFpga_Bool    value)
+{
+   return NiFpga_writeBool
+        ? NiFpga_writeBool(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeI8)(
+                             NiFpga_Session session,
+                             uint32_t       control,
+                             int8_t         value) = NULL;
+
+NiFpga_Status NiFpga_WriteI8(NiFpga_Session session,
+                             uint32_t       control,
+                             int8_t         value)
+{
+   return NiFpga_writeI8
+        ? NiFpga_writeI8(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeU8)(
+                             NiFpga_Session session,
+                             uint32_t       control,
+                             uint8_t        value) = NULL;
+
+NiFpga_Status NiFpga_WriteU8(NiFpga_Session session,
+                             uint32_t       control,
+                             uint8_t        value)
+{
+   return NiFpga_writeU8
+        ? NiFpga_writeU8(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeI16)(
+                              NiFpga_Session session,
+                              uint32_t       control,
+                              int16_t        value) = NULL;
+
+NiFpga_Status NiFpga_WriteI16(NiFpga_Session session,
+                              uint32_t       control,
+                              int16_t        value)
+{
+   return NiFpga_writeI16
+        ? NiFpga_writeI16(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeU16)(
+                              NiFpga_Session session,
+                              uint32_t       control,
+                              uint16_t       value) = NULL;
+
+NiFpga_Status NiFpga_WriteU16(NiFpga_Session session,
+                              uint32_t       control,
+                              uint16_t       value)
+{
+   return NiFpga_writeU16
+        ? NiFpga_writeU16(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeI32)(
+                              NiFpga_Session session,
+                              uint32_t       control,
+                              int32_t        value) = NULL;
+
+NiFpga_Status NiFpga_WriteI32(NiFpga_Session session,
+                              uint32_t       control,
+                              int32_t        value)
+{
+   return NiFpga_writeI32
+        ? NiFpga_writeI32(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeU32)(
+                              NiFpga_Session session,
+                              uint32_t       control,
+                              uint32_t       value) = NULL;
+
+NiFpga_Status NiFpga_WriteU32(NiFpga_Session session,
+                              uint32_t       control,
+                              uint32_t       value)
+{
+   return NiFpga_writeU32
+        ? NiFpga_writeU32(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeI64)(
+                              NiFpga_Session session,
+                              uint32_t       control,
+                              int64_t        value) = NULL;
+
+NiFpga_Status NiFpga_WriteI64(NiFpga_Session session,
+                              uint32_t       control,
+                              int64_t        value)
+{
+   return NiFpga_writeI64
+        ? NiFpga_writeI64(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeU64)(
+                              NiFpga_Session session,
+                              uint32_t       control,
+                              uint64_t       value) = NULL;
+
+NiFpga_Status NiFpga_WriteU64(NiFpga_Session session,
+                              uint32_t       control,
+                              uint64_t       value)
+{
+   return NiFpga_writeU64
+        ? NiFpga_writeU64(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeSgl)(
+                              NiFpga_Session session,
+                              uint32_t       control,
+                              float          value) = NULL;
+
+NiFpga_Status NiFpga_WriteSgl(NiFpga_Session session,
+                              uint32_t       control,
+                              float          value)
+{
+   return NiFpga_writeSgl
+        ? NiFpga_writeSgl(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeDbl)(
+                              NiFpga_Session session,
+                              uint32_t       control,
+                              double         value) = NULL;
+
+NiFpga_Status NiFpga_WriteDbl(NiFpga_Session session,
+                              uint32_t       control,
+                              double         value)
+{
+   return NiFpga_writeDbl
+        ? NiFpga_writeDbl(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/*
+ * Functions to read from array indicators and controls.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayBool)(
+                                   NiFpga_Session session,
+                                   uint32_t       indicator,
+                                   NiFpga_Bool*   array,
+                                   size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayBool(NiFpga_Session session,
+                                   uint32_t       indicator,
+                                   NiFpga_Bool*   array,
+                                   size_t         size)
+{
+   return NiFpga_readArrayBool
+        ? NiFpga_readArrayBool(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayI8)(
+                                 NiFpga_Session session,
+                                 uint32_t       indicator,
+                                 int8_t*        array,
+                                 size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayI8(NiFpga_Session session,
+                                 uint32_t       indicator,
+                                 int8_t*        array,
+                                 size_t         size)
+{
+   return NiFpga_readArrayI8
+        ? NiFpga_readArrayI8(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayU8)(
+                                 NiFpga_Session session,
+                                 uint32_t       indicator,
+                                 uint8_t*       array,
+                                 size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayU8(NiFpga_Session session,
+                                 uint32_t       indicator,
+                                 uint8_t*       array,
+                                 size_t         size)
+{
+   return NiFpga_readArrayU8
+        ? NiFpga_readArrayU8(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayI16)(
+                                  NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int16_t*       array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayI16(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int16_t*       array,
+                                  size_t         size)
+{
+   return NiFpga_readArrayI16
+        ? NiFpga_readArrayI16(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayU16)(
+                                  NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint16_t*      array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayU16(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint16_t*      array,
+                                  size_t         size)
+{
+   return NiFpga_readArrayU16
+        ? NiFpga_readArrayU16(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayI32)(
+                                  NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int32_t*       array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayI32(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int32_t*       array,
+                                  size_t         size)
+{
+   return NiFpga_readArrayI32
+        ? NiFpga_readArrayI32(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayU32)(
+                                  NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint32_t*      array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayU32(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint32_t*      array,
+                                  size_t         size)
+{
+   return NiFpga_readArrayU32
+        ? NiFpga_readArrayU32(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayI64)(
+                                  NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int64_t*       array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayI64(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int64_t*       array,
+                                  size_t         size)
+{
+   return NiFpga_readArrayI64
+        ? NiFpga_readArrayI64(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayU64)(
+                                  NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint64_t*      array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayU64(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint64_t*      array,
+                                  size_t         size)
+{
+   return NiFpga_readArrayU64
+        ? NiFpga_readArrayU64(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArraySgl)(
+                                  NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  float*         array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArraySgl(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  float*         array,
+                                  size_t         size)
+{
+   return NiFpga_readArraySgl
+        ? NiFpga_readArraySgl(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayDbl)(
+                                  NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  double*        array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayDbl(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  double*        array,
+                                  size_t         size)
+{
+   return NiFpga_readArrayDbl
+        ? NiFpga_readArrayDbl(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/*
+ * Functions to write to array controls and indicators.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayBool)(
+                                    NiFpga_Session     session,
+                                    uint32_t           control,
+                                    const NiFpga_Bool* array,
+                                    size_t             size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayBool(NiFpga_Session     session,
+                                    uint32_t           control,
+                                    const NiFpga_Bool* array,
+                                    size_t             size)
+{
+   return NiFpga_writeArrayBool
+        ? NiFpga_writeArrayBool(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayI8)(
+                                  NiFpga_Session session,
+                                  uint32_t       control,
+                                  const int8_t*  array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayI8(NiFpga_Session session,
+                                  uint32_t       control,
+                                  const int8_t*  array,
+                                  size_t         size)
+{
+   return NiFpga_writeArrayI8
+        ? NiFpga_writeArrayI8(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayU8)(
+                                  NiFpga_Session session,
+                                  uint32_t       control,
+                                  const uint8_t* array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayU8(NiFpga_Session session,
+                                  uint32_t       control,
+                                  const uint8_t* array,
+                                  size_t         size)
+{
+   return NiFpga_writeArrayU8
+        ? NiFpga_writeArrayU8(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayI16)(
+                                   NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int16_t* array,
+                                   size_t         size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayI16(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int16_t* array,
+                                   size_t         size)
+{
+   return NiFpga_writeArrayI16
+        ? NiFpga_writeArrayI16(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayU16)(
+                                   NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint16_t* array,
+                                   size_t          size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayU16(NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint16_t* array,
+                                   size_t          size)
+{
+   return NiFpga_writeArrayU16
+        ? NiFpga_writeArrayU16(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayI32)(
+                                   NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int32_t* array,
+                                   size_t         size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayI32(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int32_t* array,
+                                   size_t         size)
+{
+   return NiFpga_writeArrayI32
+        ? NiFpga_writeArrayI32(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayU32)(
+                                   NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint32_t* array,
+                                   size_t          size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayU32(NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint32_t* array,
+                                   size_t          size)
+{
+   return NiFpga_writeArrayU32
+        ? NiFpga_writeArrayU32(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayI64)(
+                                   NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int64_t* array,
+                                   size_t         size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayI64(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int64_t* array,
+                                   size_t         size)
+{
+   return NiFpga_writeArrayI64
+        ? NiFpga_writeArrayI64(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayU64)(
+                                   NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint64_t* array,
+                                   size_t          size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayU64(NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint64_t* array,
+                                   size_t          size)
+{
+   return NiFpga_writeArrayU64
+        ? NiFpga_writeArrayU64(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArraySgl)(
+                                   NiFpga_Session session,
+                                   uint32_t       control,
+                                   const float*   array,
+                                   size_t         size) = NULL;
+
+NiFpga_Status NiFpga_WriteArraySgl(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const float*   array,
+                                   size_t         size)
+{
+   return NiFpga_writeArraySgl
+        ? NiFpga_writeArraySgl(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayDbl)(
+                                   NiFpga_Session session,
+                                   uint32_t       control,
+                                   const double*  array,
+                                   size_t         size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayDbl(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const double*  array,
+                                   size_t         size)
+{
+   return NiFpga_writeArrayDbl
+        ? NiFpga_writeArrayDbl(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/*
+ * Interrupt functions.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_reserveIrqContext)(
+                                       NiFpga_Session     session,
+                                       NiFpga_IrqContext* context) = NULL;
+
+
+NiFpga_Status NiFpga_ReserveIrqContext(NiFpga_Session     session,
+                                       NiFpga_IrqContext* context)
+{
+   const NiFpga_Status result = NiFpga_reserveIrqContext
+                              ? NiFpga_reserveIrqContext(session, context)
+                              : NiFpga_Status_ResourceNotInitialized;
+   #if NiFpga_CviResourceTracking
+      if (NiFpga_acquireCviResource
+      &&  NiFpga_IsNotError(result))
+         NiFpga_acquireCviResource(*context,
+                                   NiFpga_cviResourceType,
+                                   "NiFpga_IrqContext 0x%p",
+                                   *context);
+   #endif
+   return result;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_unreserveIrqContext)(
+                                         NiFpga_Session    session,
+                                         NiFpga_IrqContext context) = NULL;
+
+
+NiFpga_Status NiFpga_UnreserveIrqContext(NiFpga_Session    session,
+                                         NiFpga_IrqContext context)
+{
+   if (!NiFpga_unreserveIrqContext)
+      return NiFpga_Status_ResourceNotInitialized;
+   #if NiFpga_CviResourceTracking
+      if (NiFpga_releaseCviResource)
+         NiFpga_releaseCviResource(context);
+   #endif
+   return NiFpga_unreserveIrqContext(session, context);
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_waitOnIrqs)(
+                                NiFpga_Session    session,
+                                NiFpga_IrqContext context,
+                                uint32_t          irqs,
+                                uint32_t          timeout,
+                                uint32_t*         irqsAsserted,
+                                NiFpga_Bool*      timedOut) = NULL;
+
+NiFpga_Status NiFpga_WaitOnIrqs(NiFpga_Session    session,
+                                NiFpga_IrqContext context,
+                                uint32_t          irqs,
+                                uint32_t          timeout,
+                                uint32_t*         irqsAsserted,
+                                NiFpga_Bool*      timedOut)
+{
+   return NiFpga_waitOnIrqs
+        ? NiFpga_waitOnIrqs(session,
+                            context,
+                            irqs,
+                            timeout,
+                            irqsAsserted,
+                            timedOut)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acknowledgeIrqs)(
+                                     NiFpga_Session session,
+                                     uint32_t       irqs) = NULL;
+
+NiFpga_Status NiFpga_AcknowledgeIrqs(NiFpga_Session session,
+                                     uint32_t       irqs)
+{
+   return NiFpga_acknowledgeIrqs
+        ? NiFpga_acknowledgeIrqs(session, irqs)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/*
+ * DMA FIFO state functions.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_configureFifo)(
+                                   NiFpga_Session session,
+                                   uint32_t       fifo,
+                                   size_t         depth) = NULL;
+
+NiFpga_Status NiFpga_ConfigureFifo(NiFpga_Session session,
+                                   uint32_t       fifo,
+                                   size_t         depth)
+{
+   return NiFpga_configureFifo
+        ? NiFpga_configureFifo(session, fifo, depth)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_configureFifo2)(
+                                   NiFpga_Session session,
+                                   uint32_t       fifo,
+                                   size_t         requestedDepth,
+                                   size_t*        actualDepth) = NULL;
+
+NiFpga_Status NiFpga_ConfigureFifo2(NiFpga_Session session,
+                                   uint32_t       fifo,
+                                   size_t         requestedDepth,
+                                   size_t*        actualDepth)
+{
+   return NiFpga_configureFifo2
+        ? NiFpga_configureFifo2(session, fifo, requestedDepth, actualDepth)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_startFifo)(
+                               NiFpga_Session session,
+                               uint32_t       fifo) = NULL;
+
+NiFpga_Status NiFpga_StartFifo(NiFpga_Session session,
+                               uint32_t       fifo)
+{
+   return NiFpga_startFifo
+        ? NiFpga_startFifo(session, fifo)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_stopFifo)(
+                              NiFpga_Session session,
+                              uint32_t       fifo) = NULL;
+
+NiFpga_Status NiFpga_StopFifo(NiFpga_Session session,
+                              uint32_t       fifo)
+{
+   return NiFpga_stopFifo
+        ? NiFpga_stopFifo(session, fifo)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/*
+ * Functions to read from target-to-host DMA FIFOs.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoBool)(
+                                  NiFpga_Session session,
+                                  uint32_t       fifo,
+                                  NiFpga_Bool*   data,
+                                  size_t         numberOfElements,
+                                  uint32_t       timeout,
+                                  size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoBool(NiFpga_Session session,
+                                  uint32_t       fifo,
+                                  NiFpga_Bool*   data,
+                                  size_t         numberOfElements,
+                                  uint32_t       timeout,
+                                  size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoBool
+        ? NiFpga_readFifoBool(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoI8)(
+                                NiFpga_Session session,
+                                uint32_t       fifo,
+                                int8_t*        data,
+                                size_t         numberOfElements,
+                                uint32_t       timeout,
+                                size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoI8(NiFpga_Session session,
+                                uint32_t       fifo,
+                                int8_t*        data,
+                                size_t         numberOfElements,
+                                uint32_t       timeout,
+                                size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoI8
+        ? NiFpga_readFifoI8(session,
+                            fifo,
+                            data,
+                            numberOfElements,
+                            timeout,
+                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoU8)(
+                                NiFpga_Session session,
+                                uint32_t       fifo,
+                                uint8_t*       data,
+                                size_t         numberOfElements,
+                                uint32_t       timeout,
+                                size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoU8(NiFpga_Session session,
+                                uint32_t       fifo,
+                                uint8_t*       data,
+                                size_t         numberOfElements,
+                                uint32_t       timeout,
+                                size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoU8
+        ? NiFpga_readFifoU8(session,
+                            fifo,
+                            data,
+                            numberOfElements,
+                            timeout,
+                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoI16)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int16_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoI16(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int16_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoI16
+        ? NiFpga_readFifoI16(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoU16)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint16_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoU16(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint16_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoU16
+        ? NiFpga_readFifoU16(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoI32)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int32_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoI32(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int32_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoI32
+        ? NiFpga_readFifoI32(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoU32)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint32_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoU32(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint32_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoU32
+        ? NiFpga_readFifoU32(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoI64)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int64_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoI64(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int64_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoI64
+        ? NiFpga_readFifoI64(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoU64)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint64_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoU64(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint64_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoU64
+        ? NiFpga_readFifoU64(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoSgl)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 float*         data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoSgl(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 float*         data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoSgl
+        ? NiFpga_readFifoSgl(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoDbl)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 double*        data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoDbl(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 double*        data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoDbl
+        ? NiFpga_readFifoDbl(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/*
+ * Functions to write to host-to-target DMA FIFOs.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoBool)(
+                             NiFpga_Session     session,
+                             uint32_t           fifo,
+                             const NiFpga_Bool* data,
+                             size_t             numberOfElements,
+                             uint32_t           timeout,
+                             size_t*            emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoBool(
+                             NiFpga_Session     session,
+                             uint32_t           fifo,
+                             const NiFpga_Bool* data,
+                             size_t             numberOfElements,
+                             uint32_t           timeout,
+                             size_t*            emptyElementsRemaining)
+{
+   return NiFpga_writeFifoBool
+        ? NiFpga_writeFifoBool(session,
+                               fifo,
+                               data,
+                               numberOfElements,
+                               timeout,
+                               emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoI8)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int8_t*  data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoI8(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int8_t*  data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining)
+{
+   return NiFpga_writeFifoI8
+        ? NiFpga_writeFifoI8(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoU8)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const uint8_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoU8(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const uint8_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining)
+{
+   return NiFpga_writeFifoU8
+        ? NiFpga_writeFifoU8(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoI16)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int16_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoI16(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int16_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining)
+{
+   return NiFpga_writeFifoI16
+        ? NiFpga_writeFifoI16(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoU16)(
+                                NiFpga_Session  session,
+                                uint32_t        fifo,
+                                const uint16_t* data,
+                                size_t          numberOfElements,
+                                uint32_t        timeout,
+                                size_t*         emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoU16(
+                                NiFpga_Session  session,
+                                uint32_t        fifo,
+                                const uint16_t* data,
+                                size_t          numberOfElements,
+                                uint32_t        timeout,
+                                size_t*         emptyElementsRemaining)
+{
+   return NiFpga_writeFifoU16
+        ? NiFpga_writeFifoU16(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoI32)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int32_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoI32(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int32_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining)
+{
+   return NiFpga_writeFifoI32
+        ? NiFpga_writeFifoI32(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoU32)(
+                                NiFpga_Session  session,
+                                uint32_t        fifo,
+                                const uint32_t* data,
+                                size_t          numberOfElements,
+                                uint32_t        timeout,
+                                size_t*         emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoU32(
+                                NiFpga_Session  session,
+                                uint32_t        fifo,
+                                const uint32_t* data,
+                                size_t          numberOfElements,
+                                uint32_t        timeout,
+                                size_t*         emptyElementsRemaining)
+{
+   return NiFpga_writeFifoU32
+        ? NiFpga_writeFifoU32(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoI64)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int64_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoI64(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int64_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining)
+{
+   return NiFpga_writeFifoI64
+        ? NiFpga_writeFifoI64(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoU64)(
+                                NiFpga_Session  session,
+                                uint32_t        fifo,
+                                const uint64_t* data,
+                                size_t          numberOfElements,
+                                uint32_t        timeout,
+                                size_t*         emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoU64(
+                                NiFpga_Session  session,
+                                uint32_t        fifo,
+                                const uint64_t* data,
+                                size_t          numberOfElements,
+                                uint32_t        timeout,
+                                size_t*         emptyElementsRemaining)
+{
+   return NiFpga_writeFifoU64
+        ? NiFpga_writeFifoU64(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoSgl)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const float*   data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoSgl(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const float*   data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining)
+{
+   return NiFpga_writeFifoSgl
+        ? NiFpga_writeFifoSgl(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoDbl)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const double*  data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoDbl(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const double*  data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining)
+{
+   return NiFpga_writeFifoDbl
+        ? NiFpga_writeFifoDbl(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsBool)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      NiFpga_Bool**  elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsBool(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      NiFpga_Bool**  elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsBool
+        ? NiFpga_acquireFifoReadElementsBool(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsI8)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int8_t**       elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsI8(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int8_t**       elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsI8
+        ? NiFpga_acquireFifoReadElementsI8(session,
+                                           fifo,
+                                           elements,
+                                           elementsRequested,
+                                           timeout,
+                                           elementsAcquired,
+                                           elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsU8)(
+                                     NiFpga_Session  session,
+                                     uint32_t        fifo,
+                                     uint8_t**       elements,
+                                     size_t          elementsRequested,
+                                     uint32_t        timeout,
+                                     size_t*         elementsAcquired,
+                                     size_t*         elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsU8(
+                                     NiFpga_Session  session,
+                                     uint32_t        fifo,
+                                     uint8_t**       elements,
+                                     size_t          elementsRequested,
+                                     uint32_t        timeout,
+                                     size_t*         elementsAcquired,
+                                     size_t*         elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsU8
+        ? NiFpga_acquireFifoReadElementsU8(session,
+                                           fifo,
+                                           elements,
+                                           elementsRequested,
+                                           timeout,
+                                           elementsAcquired,
+                                           elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsI16)(
+                                     NiFpga_Session  session,
+                                     uint32_t        fifo,
+                                     int16_t**       elements,
+                                     size_t          elementsRequested,
+                                     uint32_t        timeout,
+                                     size_t*         elementsAcquired,
+                                     size_t*         elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsI16(
+                                     NiFpga_Session  session,
+                                     uint32_t        fifo,
+                                     int16_t**       elements,
+                                     size_t          elementsRequested,
+                                     uint32_t        timeout,
+                                     size_t*         elementsAcquired,
+                                     size_t*         elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsI16
+        ? NiFpga_acquireFifoReadElementsI16(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsU16)(
+                                    NiFpga_Session   session,
+                                    uint32_t         fifo,
+                                    uint16_t**       elements,
+                                    size_t           elementsRequested,
+                                    uint32_t         timeout,
+                                    size_t*          elementsAcquired,
+                                    size_t*          elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsU16(
+                                    NiFpga_Session   session,
+                                    uint32_t         fifo,
+                                    uint16_t**       elements,
+                                    size_t           elementsRequested,
+                                    uint32_t         timeout,
+                                    size_t*          elementsAcquired,
+                                    size_t*          elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsU16
+        ? NiFpga_acquireFifoReadElementsU16(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsI32)(
+                                     NiFpga_Session  session,
+                                     uint32_t        fifo,
+                                     int32_t**       elements,
+                                     size_t          elementsRequested,
+                                     uint32_t        timeout,
+                                     size_t*         elementsAcquired,
+                                     size_t*         elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsI32(
+                                     NiFpga_Session  session,
+                                     uint32_t        fifo,
+                                     int32_t**       elements,
+                                     size_t          elementsRequested,
+                                     uint32_t        timeout,
+                                     size_t*         elementsAcquired,
+                                     size_t*         elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsI32
+        ? NiFpga_acquireFifoReadElementsI32(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsU32)(
+                                    NiFpga_Session   session,
+                                    uint32_t         fifo,
+                                    uint32_t**       elements,
+                                    size_t           elementsRequested,
+                                    uint32_t         timeout,
+                                    size_t*          elementsAcquired,
+                                    size_t*          elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsU32(
+                                    NiFpga_Session   session,
+                                    uint32_t         fifo,
+                                    uint32_t**       elements,
+                                    size_t           elementsRequested,
+                                    uint32_t         timeout,
+                                    size_t*          elementsAcquired,
+                                    size_t*          elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsU32
+        ? NiFpga_acquireFifoReadElementsU32(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsI64)(
+                                     NiFpga_Session  session,
+                                     uint32_t        fifo,
+                                     int64_t**       elements,
+                                     size_t          elementsRequested,
+                                     uint32_t        timeout,
+                                     size_t*         elementsAcquired,
+                                     size_t*         elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsI64(
+                                     NiFpga_Session  session,
+                                     uint32_t        fifo,
+                                     int64_t**       elements,
+                                     size_t          elementsRequested,
+                                     uint32_t        timeout,
+                                     size_t*         elementsAcquired,
+                                     size_t*         elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsI64
+        ? NiFpga_acquireFifoReadElementsI64(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsU64)(
+                                    NiFpga_Session   session,
+                                    uint32_t         fifo,
+                                    uint64_t**       elements,
+                                    size_t           elementsRequested,
+                                    uint32_t         timeout,
+                                    size_t*          elementsAcquired,
+                                    size_t*          elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsU64(
+                                    NiFpga_Session   session,
+                                    uint32_t         fifo,
+                                    uint64_t**       elements,
+                                    size_t           elementsRequested,
+                                    uint32_t         timeout,
+                                    size_t*          elementsAcquired,
+                                    size_t*          elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsU64
+        ? NiFpga_acquireFifoReadElementsU64(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsSgl)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      float**        elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsSgl(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      float**        elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsSgl
+        ? NiFpga_acquireFifoReadElementsSgl(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsDbl)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      double**       elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsDbl(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      double**       elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsDbl
+        ? NiFpga_acquireFifoReadElementsDbl(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsBool)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      NiFpga_Bool**  elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsBool(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      NiFpga_Bool**  elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsBool
+        ? NiFpga_acquireFifoWriteElementsBool(session,
+                                              fifo,
+                                              elements,
+                                              elementsRequested,
+                                              timeout,
+                                              elementsAcquired,
+                                              elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsI8)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int8_t**       elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI8(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int8_t**       elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsI8
+        ? NiFpga_acquireFifoWriteElementsI8(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsU8)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      uint8_t**      elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU8(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      uint8_t**      elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsU8
+        ? NiFpga_acquireFifoWriteElementsU8(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsI16)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int16_t**      elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI16(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int16_t**      elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsI16
+        ? NiFpga_acquireFifoWriteElementsI16(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsU16)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      uint16_t**     elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU16(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      uint16_t**     elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsU16
+        ? NiFpga_acquireFifoWriteElementsU16(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsI32)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int32_t**      elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI32(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int32_t**      elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsI32
+        ? NiFpga_acquireFifoWriteElementsI32(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsU32)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      uint32_t**     elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU32(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      uint32_t**     elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsU32
+        ? NiFpga_acquireFifoWriteElementsU32(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsI64)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int64_t**      elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI64(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int64_t**      elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsI64
+        ? NiFpga_acquireFifoWriteElementsI64(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsU64)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      uint64_t**     elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU64(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      uint64_t**     elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsU64
+        ? NiFpga_acquireFifoWriteElementsU64(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsSgl)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      float**        elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsSgl(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      float**        elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsSgl
+        ? NiFpga_acquireFifoWriteElementsSgl(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsDbl)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      double**       elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsDbl(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      double**       elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsDbl
+        ? NiFpga_acquireFifoWriteElementsDbl(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_releaseFifoElements)(
+                                         NiFpga_Session session,
+                                         uint32_t       fifo,
+                                         size_t         elements) = NULL;
+
+NiFpga_Status NiFpga_ReleaseFifoElements(NiFpga_Session session,
+                                         uint32_t       fifo,
+                                         size_t         elements)
+{
+   return NiFpga_releaseFifoElements
+        ? NiFpga_releaseFifoElements(session, fifo, elements)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_getPeerToPeerFifoEndpoint)(
+                                         NiFpga_Session session,
+                                         uint32_t       fifo,
+                                         uint32_t*      endpoint) = NULL;
+
+NiFpga_Status NiFpga_GetPeerToPeerFifoEndpoint(NiFpga_Session session,
+                                         uint32_t       fifo,
+                                         uint32_t*      endpoint)
+{
+   return NiFpga_getPeerToPeerFifoEndpoint
+        ? NiFpga_getPeerToPeerFifoEndpoint(session, fifo, endpoint)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_getBitfileContents)(
+                                        NiFpga_Session session,
+                                        const char**   contents) = NULL;
+
+NiFpga_Status NiFpga_GetBitfileContents(NiFpga_Session session,
+                                        const char**   contents)
+{
+   return NiFpga_getBitfileContents
+        ? NiFpga_getBitfileContents(session, contents)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_clientFunctionCall)(
+                                        NiFpga_Session session,
+                                        uint32_t group,
+                                        uint32_t functionId,
+                                        const void* inBuffer,
+                                        size_t inBufferSize,
+                                        void* outBuffer,
+                                        size_t outBufferSize) = NULL;
+
+NiFpga_Status NiFpga_ClientFunctionCall(NiFpga_Session session,
+                                        uint32_t group,
+                                        uint32_t functionId,
+                                        const void* inBuffer,
+                                        size_t inBufferSize,
+                                        void* outBuffer,
+                                        size_t outBufferSize)
+{
+   return NiFpga_clientFunctionCall
+        ? NiFpga_clientFunctionCall(session, group, functionId, inBuffer, inBufferSize, outBuffer, outBufferSize)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/**
+ * A type large enough to hold entry point function pointer.
+ */
+typedef NiFpga_Status (NiFpga_CCall *NiFpga_FunctionPointer)();
+
+/**
+ * A NULL-terminated array of all entry point functions.
+ */
+static const struct
+{
+   const char* const name;
+   NiFpga_FunctionPointer* const address;
+} NiFpga_functions[] =
+{
+   {"NiFpgaDll_Open",                (NiFpga_FunctionPointer*)&NiFpga_open},
+   {"NiFpgaDll_Close",               (NiFpga_FunctionPointer*)&NiFpga_close},
+   {"NiFpgaDll_Run",                 (NiFpga_FunctionPointer*)&NiFpga_run},
+   {"NiFpgaDll_Abort",               (NiFpga_FunctionPointer*)&NiFpga_abort},
+   {"NiFpgaDll_Reset",               (NiFpga_FunctionPointer*)&NiFpga_reset},
+   {"NiFpgaDll_Download",            (NiFpga_FunctionPointer*)&NiFpga_download},
+   {"NiFpgaDll_ReadBool",            (NiFpga_FunctionPointer*)&NiFpga_readBool},
+   {"NiFpgaDll_ReadI8",              (NiFpga_FunctionPointer*)&NiFpga_readI8},
+   {"NiFpgaDll_ReadU8",              (NiFpga_FunctionPointer*)&NiFpga_readU8},
+   {"NiFpgaDll_ReadI16",             (NiFpga_FunctionPointer*)&NiFpga_readI16},
+   {"NiFpgaDll_ReadU16",             (NiFpga_FunctionPointer*)&NiFpga_readU16},
+   {"NiFpgaDll_ReadI32",             (NiFpga_FunctionPointer*)&NiFpga_readI32},
+   {"NiFpgaDll_ReadU32",             (NiFpga_FunctionPointer*)&NiFpga_readU32},
+   {"NiFpgaDll_ReadI64",             (NiFpga_FunctionPointer*)&NiFpga_readI64},
+   {"NiFpgaDll_ReadU64",             (NiFpga_FunctionPointer*)&NiFpga_readU64},
+   {"NiFpgaDll_ReadSgl",             (NiFpga_FunctionPointer*)&NiFpga_readSgl},
+   {"NiFpgaDll_ReadDbl",             (NiFpga_FunctionPointer*)&NiFpga_readDbl},
+   {"NiFpgaDll_WriteBool",           (NiFpga_FunctionPointer*)&NiFpga_writeBool},
+   {"NiFpgaDll_WriteI8",             (NiFpga_FunctionPointer*)&NiFpga_writeI8},
+   {"NiFpgaDll_WriteU8",             (NiFpga_FunctionPointer*)&NiFpga_writeU8},
+   {"NiFpgaDll_WriteI16",            (NiFpga_FunctionPointer*)&NiFpga_writeI16},
+   {"NiFpgaDll_WriteU16",            (NiFpga_FunctionPointer*)&NiFpga_writeU16},
+   {"NiFpgaDll_WriteI32",            (NiFpga_FunctionPointer*)&NiFpga_writeI32},
+   {"NiFpgaDll_WriteU32",            (NiFpga_FunctionPointer*)&NiFpga_writeU32},
+   {"NiFpgaDll_WriteI64",            (NiFpga_FunctionPointer*)&NiFpga_writeI64},
+   {"NiFpgaDll_WriteU64",            (NiFpga_FunctionPointer*)&NiFpga_writeU64},
+   {"NiFpgaDll_WriteSgl",            (NiFpga_FunctionPointer*)&NiFpga_writeSgl},
+   {"NiFpgaDll_WriteDbl",            (NiFpga_FunctionPointer*)&NiFpga_writeDbl},
+   {"NiFpgaDll_ReadArrayBool",       (NiFpga_FunctionPointer*)&NiFpga_readArrayBool},
+   {"NiFpgaDll_ReadArrayI8",         (NiFpga_FunctionPointer*)&NiFpga_readArrayI8},
+   {"NiFpgaDll_ReadArrayU8",         (NiFpga_FunctionPointer*)&NiFpga_readArrayU8},
+   {"NiFpgaDll_ReadArrayI16",        (NiFpga_FunctionPointer*)&NiFpga_readArrayI16},
+   {"NiFpgaDll_ReadArrayU16",        (NiFpga_FunctionPointer*)&NiFpga_readArrayU16},
+   {"NiFpgaDll_ReadArrayI32",        (NiFpga_FunctionPointer*)&NiFpga_readArrayI32},
+   {"NiFpgaDll_ReadArrayU32",        (NiFpga_FunctionPointer*)&NiFpga_readArrayU32},
+   {"NiFpgaDll_ReadArrayI64",        (NiFpga_FunctionPointer*)&NiFpga_readArrayI64},
+   {"NiFpgaDll_ReadArrayU64",        (NiFpga_FunctionPointer*)&NiFpga_readArrayU64},
+   {"NiFpgaDll_ReadArraySgl",        (NiFpga_FunctionPointer*)&NiFpga_readArraySgl},
+   {"NiFpgaDll_ReadArrayDbl",        (NiFpga_FunctionPointer*)&NiFpga_readArrayDbl},
+   {"NiFpgaDll_WriteArrayBool",      (NiFpga_FunctionPointer*)&NiFpga_writeArrayBool},
+   {"NiFpgaDll_WriteArrayI8",        (NiFpga_FunctionPointer*)&NiFpga_writeArrayI8},
+   {"NiFpgaDll_WriteArrayU8",        (NiFpga_FunctionPointer*)&NiFpga_writeArrayU8},
+   {"NiFpgaDll_WriteArrayI16",       (NiFpga_FunctionPointer*)&NiFpga_writeArrayI16},
+   {"NiFpgaDll_WriteArrayU16",       (NiFpga_FunctionPointer*)&NiFpga_writeArrayU16},
+   {"NiFpgaDll_WriteArrayI32",       (NiFpga_FunctionPointer*)&NiFpga_writeArrayI32},
+   {"NiFpgaDll_WriteArrayU32",       (NiFpga_FunctionPointer*)&NiFpga_writeArrayU32},
+   {"NiFpgaDll_WriteArrayI64",       (NiFpga_FunctionPointer*)&NiFpga_writeArrayI64},
+   {"NiFpgaDll_WriteArrayU64",       (NiFpga_FunctionPointer*)&NiFpga_writeArrayU64},
+   {"NiFpgaDll_WriteArraySgl",       (NiFpga_FunctionPointer*)&NiFpga_writeArraySgl},
+   {"NiFpgaDll_WriteArrayDbl",       (NiFpga_FunctionPointer*)&NiFpga_writeArrayDbl},
+   {"NiFpgaDll_ReserveIrqContext",   (NiFpga_FunctionPointer*)&NiFpga_reserveIrqContext},
+   {"NiFpgaDll_UnreserveIrqContext", (NiFpga_FunctionPointer*)&NiFpga_unreserveIrqContext},
+   {"NiFpgaDll_WaitOnIrqs",          (NiFpga_FunctionPointer*)&NiFpga_waitOnIrqs},
+   {"NiFpgaDll_AcknowledgeIrqs",     (NiFpga_FunctionPointer*)&NiFpga_acknowledgeIrqs},
+   {"NiFpgaDll_ConfigureFifo",       (NiFpga_FunctionPointer*)&NiFpga_configureFifo},
+   {"NiFpgaDll_ConfigureFifo2",      (NiFpga_FunctionPointer*)&NiFpga_configureFifo2},
+   {"NiFpgaDll_StartFifo",           (NiFpga_FunctionPointer*)&NiFpga_startFifo},
+   {"NiFpgaDll_StopFifo",            (NiFpga_FunctionPointer*)&NiFpga_stopFifo},
+   {"NiFpgaDll_ReadFifoBool",        (NiFpga_FunctionPointer*)&NiFpga_readFifoBool},
+   {"NiFpgaDll_ReadFifoI8",          (NiFpga_FunctionPointer*)&NiFpga_readFifoI8},
+   {"NiFpgaDll_ReadFifoU8",          (NiFpga_FunctionPointer*)&NiFpga_readFifoU8},
+   {"NiFpgaDll_ReadFifoI16",         (NiFpga_FunctionPointer*)&NiFpga_readFifoI16},
+   {"NiFpgaDll_ReadFifoU16",         (NiFpga_FunctionPointer*)&NiFpga_readFifoU16},
+   {"NiFpgaDll_ReadFifoI32",         (NiFpga_FunctionPointer*)&NiFpga_readFifoI32},
+   {"NiFpgaDll_ReadFifoU32",         (NiFpga_FunctionPointer*)&NiFpga_readFifoU32},
+   {"NiFpgaDll_ReadFifoI64",         (NiFpga_FunctionPointer*)&NiFpga_readFifoI64},
+   {"NiFpgaDll_ReadFifoU64",         (NiFpga_FunctionPointer*)&NiFpga_readFifoU64},
+   {"NiFpgaDll_ReadFifoSgl",         (NiFpga_FunctionPointer*)&NiFpga_readFifoSgl},
+   {"NiFpgaDll_ReadFifoDbl",         (NiFpga_FunctionPointer*)&NiFpga_readFifoDbl},
+   {"NiFpgaDll_WriteFifoBool",       (NiFpga_FunctionPointer*)&NiFpga_writeFifoBool},
+   {"NiFpgaDll_WriteFifoI8",         (NiFpga_FunctionPointer*)&NiFpga_writeFifoI8},
+   {"NiFpgaDll_WriteFifoU8",         (NiFpga_FunctionPointer*)&NiFpga_writeFifoU8},
+   {"NiFpgaDll_WriteFifoI16",        (NiFpga_FunctionPointer*)&NiFpga_writeFifoI16},
+   {"NiFpgaDll_WriteFifoU16",        (NiFpga_FunctionPointer*)&NiFpga_writeFifoU16},
+   {"NiFpgaDll_WriteFifoI32",        (NiFpga_FunctionPointer*)&NiFpga_writeFifoI32},
+   {"NiFpgaDll_WriteFifoU32",        (NiFpga_FunctionPointer*)&NiFpga_writeFifoU32},
+   {"NiFpgaDll_WriteFifoI64",        (NiFpga_FunctionPointer*)&NiFpga_writeFifoI64},
+   {"NiFpgaDll_WriteFifoU64",        (NiFpga_FunctionPointer*)&NiFpga_writeFifoU64},
+   {"NiFpgaDll_WriteFifoSgl",        (NiFpga_FunctionPointer*)&NiFpga_writeFifoSgl},
+   {"NiFpgaDll_WriteFifoDbl",        (NiFpga_FunctionPointer*)&NiFpga_writeFifoDbl},
+   {"NiFpgaDll_AcquireFifoReadElementsBool",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsBool},
+   {"NiFpgaDll_AcquireFifoReadElementsI8",    (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsI8},
+   {"NiFpgaDll_AcquireFifoReadElementsU8",    (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsU8},
+   {"NiFpgaDll_AcquireFifoReadElementsI16",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsI16},
+   {"NiFpgaDll_AcquireFifoReadElementsU16",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsU16},
+   {"NiFpgaDll_AcquireFifoReadElementsI32",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsI32},
+   {"NiFpgaDll_AcquireFifoReadElementsU32",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsU32},
+   {"NiFpgaDll_AcquireFifoReadElementsI64",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsI64},
+   {"NiFpgaDll_AcquireFifoReadElementsU64",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsU64},
+   {"NiFpgaDll_AcquireFifoReadElementsSgl",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsSgl},
+   {"NiFpgaDll_AcquireFifoReadElementsDbl",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsDbl},
+   {"NiFpgaDll_AcquireFifoWriteElementsBool", (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsBool},
+   {"NiFpgaDll_AcquireFifoWriteElementsI8",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsI8},
+   {"NiFpgaDll_AcquireFifoWriteElementsU8",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsU8},
+   {"NiFpgaDll_AcquireFifoWriteElementsI16",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsI16},
+   {"NiFpgaDll_AcquireFifoWriteElementsU16",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsU16},
+   {"NiFpgaDll_AcquireFifoWriteElementsI32",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsI32},
+   {"NiFpgaDll_AcquireFifoWriteElementsU32",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsU32},
+   {"NiFpgaDll_AcquireFifoWriteElementsI64",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsI64},
+   {"NiFpgaDll_AcquireFifoWriteElementsU64",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsU64},
+   {"NiFpgaDll_AcquireFifoWriteElementsSgl",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsSgl},
+   {"NiFpgaDll_AcquireFifoWriteElementsDbl",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsDbl},
+   {"NiFpgaDll_ReleaseFifoElements",          (NiFpga_FunctionPointer*)&NiFpga_releaseFifoElements},
+   {"NiFpgaDll_GetPeerToPeerFifoEndpoint",    (NiFpga_FunctionPointer*)&NiFpga_getPeerToPeerFifoEndpoint},
+   {"NiFpgaDll_GetBitfileContents",           (NiFpga_FunctionPointer*)&NiFpga_getBitfileContents},
+   {"NiFpgaDll_ClientFunctionCall",           (NiFpga_FunctionPointer*)&NiFpga_clientFunctionCall},
+   {NULL, NULL}
+};
+
+NiFpga_Status NiFpga_Initialize(void)
+{
+   /* if the library isn't already loaded */
+   if (!NiFpga_library)
+   {
+      int i;
+      /* load the library */
+      #if NiFpga_Windows
+         NiFpga_library = LoadLibraryA("NiFpga.dll");
+      #elif NiFpga_VxWorks
+         NiFpga_library = VxLoadLibraryFromPath("NiFpga.out", 0);
+      #elif NiFpga_Linux || NiFpga_MacOsX
+         #if NiFpga_Linux
+            const char* const library = "libNiFpga.so";
+         #elif NiFpga_MacOsX
+            const char* const library =
+               "/Library/Frameworks/NiFpga.framework/NiFpga";
+         #endif
+         NiFpga_library = dlopen(library, RTLD_LAZY);
+         if (!NiFpga_library)
+            fprintf(stderr, "Error opening %s: %s\n", library, dlerror());
+      #else
+         #error
+      #endif
+      if (!NiFpga_library)
+         return NiFpga_Status_ResourceNotFound;
+      /* get each exported function */
+      for (i = 0; NiFpga_functions[i].name; i++)
+      {
+         const char* const name = NiFpga_functions[i].name;
+         NiFpga_FunctionPointer* const address = NiFpga_functions[i].address;
+         #if NiFpga_Windows
+            *address = (NiFpga_FunctionPointer)GetProcAddress(NiFpga_library,
+                                                              name);
+            if (!*address)
+               return NiFpga_Status_VersionMismatch;
+         #elif NiFpga_VxWorks
+            SYM_TYPE type;
+            if (symFindByName(sysSymTbl,
+                              (char*)name,
+                              (char**)address,
+                              &type) != OK)
+               return NiFpga_Status_VersionMismatch;
+         #elif NiFpga_Linux || NiFpga_MacOsX
+            *address = (NiFpga_FunctionPointer)dlsym(NiFpga_library, name);
+            if (!*address)
+               return NiFpga_Status_VersionMismatch;
+         #else
+            #error
+         #endif
+      }
+      /* enable CVI Resource Tracking, if available */
+      #if NiFpga_CviResourceTracking
+      {
+         HMODULE engine = GetModuleHandle("cvirte.dll");
+         if (!engine)
+            engine = GetModuleHandle("cvi_lvrt.dll");
+         if (!engine)
+            engine = GetModuleHandle("instrsup.dll");
+         if (engine)
+         {
+            NiFpga_acquireCviResource =
+               (NiFpga_AcquireCviResource)
+                  GetProcAddress(engine, "__CVI_Resource_Acquire");
+            NiFpga_releaseCviResource =
+               (NiFpga_ReleaseCviResource)
+                  GetProcAddress(engine, "__CVI_Resource_Release");
+            if (!NiFpga_acquireCviResource
+            ||  !NiFpga_releaseCviResource)
+            {
+               NiFpga_acquireCviResource = NULL;
+               NiFpga_releaseCviResource = NULL;
+            }
+         }
+      }
+      #endif
+   }
+   return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_Finalize(void)
+{
+   /* if the library is currently loaded */
+   if (NiFpga_library)
+   {
+      int i;
+      NiFpga_Status status = NiFpga_Status_Success;
+      /* unload the library */
+      #if NiFpga_Windows
+         if (!FreeLibrary(NiFpga_library))
+            status = NiFpga_Status_ResourceNotInitialized;
+      #elif NiFpga_VxWorks
+         if (VxFreeLibrary(NiFpga_library, 0) != OK)
+            status = NiFpga_Status_ResourceNotInitialized;
+      #elif NiFpga_Linux || NiFpga_MacOsX
+         if (dlclose(NiFpga_library))
+            status = NiFpga_Status_ResourceNotInitialized;
+      #else
+         #error
+      #endif
+      /* null out the library and each exported function */
+      NiFpga_library = NULL;
+      for (i = 0; NiFpga_functions[i].name; i++)
+         *NiFpga_functions[i].address = NULL;
+      /* null out the CVI Resource Tracking functions */
+      #if NiFpga_CviResourceTracking
+         NiFpga_acquireCviResource = NULL;
+         NiFpga_releaseCviResource = NULL;
+      #endif
+      return status;
+   }
+   else
+      return NiFpga_Status_ResourceNotInitialized;
+}

--- a/aoldaq/src/NiFpga.h
+++ b/aoldaq/src/NiFpga.h
@@ -1,0 +1,2807 @@
+/*
+ * FPGA Interface C API 17.0 header file.
+ *
+ * Copyright (c) 2017,
+ * National Instruments Corporation.
+ * All rights reserved.
+ */
+
+#ifndef __NiFpga_h__
+#define __NiFpga_h__
+
+/*
+ * Determine platform details.
+ */
+#if defined(_M_IX86) \
+ || defined(_M_X64) \
+ || defined(_M_AMD64) \
+ || defined(i386) \
+ || defined(__i386) \
+ || defined(__i386__) \
+ || defined(__i486__) \
+ || defined(__i586__) \
+ || defined(__i686__) \
+ || defined(__amd64__) \
+ || defined(__amd64) \
+ || defined(__x86_64__) \
+ || defined(__x86_64) \
+ || defined(__IA32__) \
+ || defined(_X86_) \
+ || defined(__THW_INTEL__) \
+ || defined(__I86__) \
+ || defined(__INTEL__) \
+ || defined(__X86__) \
+ || defined(__386__) \
+ || defined(__I86__) \
+ || defined(M_I386) \
+ || defined(M_I86) \
+ || defined(_M_I386) \
+ || defined(_M_I86)
+   #if defined(_WIN32) \
+    || defined(_WIN64) \
+    || defined(__WIN32__) \
+    || defined(__TOS_WIN__) \
+    || defined(__WINDOWS__) \
+    || defined(_WINDOWS) \
+    || defined(__WINDOWS_386__) \
+    || defined(__CYGWIN__)
+      /* Either Windows or Phar Lap ETS. */
+      #define NiFpga_Windows 1
+   #elif defined(__linux__) \
+      || defined(__linux) \
+      || defined(linux) \
+      || defined(__gnu_linux__)
+      #define NiFpga_Linux 1
+   #elif defined(__APPLE__) && defined(__MACH__)
+      #define NiFpga_MacOsX 1
+   #else
+      #error Unsupported OS.
+   #endif
+#elif defined(__powerpc) \
+   || defined(__powerpc__) \
+   || defined(__POWERPC__) \
+   || defined(__ppc__) \
+   || defined(__PPC) \
+   || defined(_M_PPC) \
+   || defined(_ARCH_PPC) \
+   || defined(__PPC__) \
+   || defined(__ppc)
+   #if defined(__vxworks)
+      #define NiFpga_VxWorks 1
+   #else
+      #error Unsupported OS.
+   #endif
+#elif defined(__arm__) \
+   || defined(__thumb__) \
+   || defined(__TARGET_ARCH_ARM) \
+   || defined(__TARGET_ARCH_THUMB) \
+   || defined(_ARM) \
+   || defined(_M_ARM) \
+   || defined(_M_ARMT)
+#if defined(__linux__) \
+ || defined(__linux) \
+ || defined(linux) \
+ || defined(__gnu_linux__)
+   #define NiFpga_Linux 1
+#else
+      #error Unsupported OS.
+   #endif
+#else
+   #error Unsupported architecture.
+#endif
+
+/*
+ * Determine compiler.
+ */
+#if defined(_MSC_VER)
+   #define NiFpga_Msvc 1
+#elif defined(__GNUC__)
+   #define NiFpga_Gcc 1
+#elif defined(_CVI_) && !defined(_TPC_)
+   #define NiFpga_Cvi 1
+   /* Enables CVI Library Protection Errors. */
+   #pragma EnableLibraryRuntimeChecking
+#else
+   /* Unknown compiler. */
+#endif
+
+/*
+ * Determine compliance with different C/C++ language standards.
+ */
+#if defined(__cplusplus)
+   #define NiFpga_Cpp 1
+   #if __cplusplus >= 199707L
+      #define NiFpga_Cpp98 1
+      #if __cplusplus >= 201103L
+         #define NiFpga_Cpp11 1
+      #endif
+   #endif
+#endif
+#if defined(__STDC__)
+   #define NiFpga_C89 1
+   #if defined(__STDC_VERSION__)
+      #define NiFpga_C90 1
+      #if __STDC_VERSION__ >= 199409L
+         #define NiFpga_C94 1
+         #if __STDC_VERSION__ >= 199901L
+            #define NiFpga_C99 1
+            #if __STDC_VERSION__ >= 201112L
+               #define NiFpga_C11 1
+            #endif
+         #endif
+      #endif
+   #endif
+#endif
+
+/*
+ * Determine ability to inline functions.
+ */
+#if NiFpga_Cpp || NiFpga_C99
+   /* The inline keyword exists in C++ and C99. */
+   #define NiFpga_Inline inline
+#elif NiFpga_Msvc
+   /* Visual C++ (at least since 6.0) also supports an alternate keyword. */
+   #define NiFpga_Inline __inline
+#elif NiFpga_Gcc
+   /* GCC (at least since 2.95.2) also supports an alternate keyword. */
+   #define NiFpga_Inline __inline__
+#elif !defined(NiFpga_Inline)
+   /*
+    * Disable inlining if inline support is unknown. To manually enable
+    * inlining, #define the following macro before #including NiFpga.h:
+    *
+    *    #define NiFpga_Inline inline
+    */
+   #define NiFpga_Inline
+#endif
+
+/*
+ * Define exact-width integer types, if they have not already been defined.
+ */
+#if NiFpga_ExactWidthIntegerTypesDefined \
+ || defined(_STDINT) \
+ || defined(_STDINT_H) \
+ || defined(_STDINT_H_) \
+ || defined(_INTTYPES_H) \
+ || defined(_INTTYPES_H_) \
+ || defined(_SYS_STDINT_H) \
+ || defined(_SYS_STDINT_H_) \
+ || defined(_SYS_INTTYPES_H) \
+ || defined(_SYS_INTTYPES_H_) \
+ || defined(_STDINT_H_INCLUDED) \
+ || defined(_MSC_STDINT_H_) \
+ || defined(_PSTDINT_H_INCLUDED)
+   /* Assume that exact-width integer types have already been defined. */
+#elif NiFpga_VxWorks
+   /* VxWorks (at least 6.3 and earlier) did not have stdint.h. */
+   #include <types/vxTypes.h>
+#elif NiFpga_C99 \
+   || NiFpga_Gcc /* GCC (at least since 3.0) has a stdint.h. */ \
+   || defined(HAVE_STDINT_H)
+   /* Assume that stdint.h can be included. */
+   #include <stdint.h>
+#elif NiFpga_Msvc \
+   || NiFpga_Cvi
+   /* Manually define exact-width integer types. */
+   typedef   signed    char  int8_t;
+   typedef unsigned    char uint8_t;
+   typedef            short  int16_t;
+   typedef unsigned   short uint16_t;
+   typedef          __int32  int32_t;
+   typedef unsigned __int32 uint32_t;
+   typedef          __int64  int64_t;
+   typedef unsigned __int64 uint64_t;
+#else
+   /*
+    * Exact-width integer types must be defined by the user, and the following
+    * macro must be #defined, before #including NiFpga.h:
+    *
+    *    #define NiFpga_ExactWidthIntegerTypesDefined 1
+    */
+   #error Exact-width integer types must be defined by the user. See comment.
+#endif
+
+/* Included for definition of size_t. */
+#include <stddef.h>
+
+#if NiFpga_Cpp
+extern "C"
+{
+#endif
+
+/**
+ * A boolean value; either NiFpga_False or NiFpga_True.
+ */
+typedef uint8_t NiFpga_Bool;
+
+/**
+ * Represents a false condition.
+ */
+static const NiFpga_Bool NiFpga_False = 0;
+
+/**
+ * Represents a true condition.
+ */
+static const NiFpga_Bool NiFpga_True = 1;
+
+/**
+ * Represents the resulting status of a function call through its return value.
+ * 0 is success, negative values are errorint_ts, and positive values are warnings.
+ */
+typedef int32_t NiFpga_Status;
+
+/**
+ * No errors or warnings.
+ */
+static const NiFpga_Status NiFpga_Status_Success = 0;
+
+/**
+ * The timeout expired before the FIFO operation could complete.
+ */
+static const NiFpga_Status NiFpga_Status_FifoTimeout = -50400;
+
+/**
+ * No transfer is in progress because the transfer was aborted by the client.
+ * The operation could not be completed as specified.
+ */
+static const NiFpga_Status NiFpga_Status_TransferAborted = -50405;
+
+/**
+ * A memory allocation failed. Try again after rebooting.
+ */
+static const NiFpga_Status NiFpga_Status_MemoryFull = -52000;
+
+/**
+ * An unexpected software error occurred.
+ */
+static const NiFpga_Status NiFpga_Status_SoftwareFault = -52003;
+
+/**
+ * A parameter to a function was not valid. This could be a NULL pointer, a bad
+ * value, etc.
+ */
+static const NiFpga_Status NiFpga_Status_InvalidParameter = -52005;
+
+/**
+ * A required resource was not found. The NiFpga.* library, the RIO resource, or
+ * some other resource may be missing.
+ */
+static const NiFpga_Status NiFpga_Status_ResourceNotFound = -52006;
+
+/**
+ * A required resource was not properly initialized. This could occur if
+ * NiFpga_Initialize was not called or a required NiFpga_IrqContext was not
+ * reserved.
+ */
+static const NiFpga_Status NiFpga_Status_ResourceNotInitialized = -52010;
+
+/**
+ * The FPGA is already running.
+ */
+static const NiFpga_Status NiFpga_Status_FpgaAlreadyRunning = -61003;
+
+/**
+ * An error occurred downloading the VI to the FPGA device. Verify that
+ * the target is connected and powered and that the resource of the target
+ * is properly configured.
+ */
+static const NiFpga_Status NiFpga_Status_DownloadError = -61018;
+
+/**
+ * The bitfile was not compiled for the specified resource's device type.
+ */
+static const NiFpga_Status NiFpga_Status_DeviceTypeMismatch = -61024;
+
+/**
+ * An error was detected in the communication between the host computer and the
+ * FPGA target.
+ */
+static const NiFpga_Status NiFpga_Status_CommunicationTimeout = -61046;
+
+/**
+ * The timeout expired before any of the IRQs were asserted.
+ */
+static const NiFpga_Status NiFpga_Status_IrqTimeout = -61060;
+
+/**
+ * The specified bitfile is invalid or corrupt.
+ */
+static const NiFpga_Status NiFpga_Status_CorruptBitfile = -61070;
+
+/**
+ * The requested FIFO depth is invalid. It is either 0 or an amount not
+ * supported by the hardware.
+ */
+static const NiFpga_Status NiFpga_Status_BadDepth = -61072;
+
+/**
+ * The number of FIFO elements is invalid. Either the number is greater than the
+ * depth of the host memory DMA FIFO, or more elements were requested for
+ * release than had been acquired.
+ */
+static const NiFpga_Status NiFpga_Status_BadReadWriteCount = -61073;
+
+/**
+ * A hardware clocking error occurred. A derived clock lost lock with its base
+ * clock during the execution of the LabVIEW FPGA VI. If any base clocks with
+ * derived clocks are referencing an external source, make sure that the
+ * external source is connected and within the supported frequency, jitter,
+ * accuracy, duty cycle, and voltage specifications. Also verify that the
+ * characteristics of the base clock match the configuration specified in the
+ * FPGA Base Clock Properties. If all base clocks with derived clocks are
+ * generated from free-running, on-board sources, please contact National
+ * Instruments technical support at ni.com/support.
+ */
+static const NiFpga_Status NiFpga_Status_ClockLostLock = -61083;
+
+/**
+ * The operation could not be performed because the FPGA is busy. Stop all
+ * activities on the FPGA before requesting this operation. If the target is in
+ * Scan Interface programming mode, put it in FPGA Interface programming mode.
+ */
+static const NiFpga_Status NiFpga_Status_FpgaBusy = -61141;
+
+/**
+ * The operation could not be performed because the FPGA is busy operating in
+ * FPGA Interface C API mode. Stop all activities on the FPGA before requesting
+ * this operation.
+ */
+static const NiFpga_Status NiFpga_Status_FpgaBusyFpgaInterfaceCApi = -61200;
+
+/**
+ * The chassis is in Scan Interface programming mode. In order to run FPGA VIs,
+ * you must go to the chassis properties page, select FPGA programming mode, and
+ * deploy settings.
+ */
+static const NiFpga_Status NiFpga_Status_FpgaBusyScanInterface = -61201;
+
+/**
+ * The operation could not be performed because the FPGA is busy operating in
+ * FPGA Interface mode. Stop all activities on the FPGA before requesting this
+ * operation.
+ */
+static const NiFpga_Status NiFpga_Status_FpgaBusyFpgaInterface = -61202;
+
+/**
+ * The operation could not be performed because the FPGA is busy operating in
+ * Interactive mode. Stop all activities on the FPGA before requesting this
+ * operation.
+ */
+static const NiFpga_Status NiFpga_Status_FpgaBusyInteractive = -61203;
+
+/**
+ * The operation could not be performed because the FPGA is busy operating in
+ * Emulation mode. Stop all activities on the FPGA before requesting this
+ * operation.
+ */
+static const NiFpga_Status NiFpga_Status_FpgaBusyEmulation = -61204;
+
+/**
+ * LabVIEW FPGA does not support the Reset method for bitfiles that allow
+ * removal of implicit enable signals in single-cycle Timed Loops.
+ */
+static const NiFpga_Status NiFpga_Status_ResetCalledWithImplicitEnableRemoval = -61211;
+
+/**
+ * LabVIEW FPGA does not support the Abort method for bitfiles that allow
+ * removal of implicit enable signals in single-cycle Timed Loops.
+ */
+static const NiFpga_Status NiFpga_Status_AbortCalledWithImplicitEnableRemoval = -61212;
+
+/**
+ * LabVIEW FPGA does not support Close and Reset if Last Reference for bitfiles
+ * that allow removal of implicit enable signals in single-cycle Timed Loops.
+ * Pass the NiFpga_CloseAttribute_NoResetIfLastSession attribute to NiFpga_Close
+ * instead of 0.
+ */
+static const NiFpga_Status NiFpga_Status_CloseAndResetCalledWithImplicitEnableRemoval = -61213;
+
+/**
+ * For bitfiles that allow removal of implicit enable signals in single-cycle
+ * Timed Loops, LabVIEW FPGA does not support this method prior to running the
+ * bitfile.
+ */
+static const NiFpga_Status NiFpga_Status_ImplicitEnableRemovalButNotYetRun = -61214;
+
+/**
+ * Bitfiles that allow removal of implicit enable signals in single-cycle Timed
+ * Loops can run only once. Download the bitfile again before re-running the VI.
+ */
+static const NiFpga_Status NiFpga_Status_RunAfterStoppedCalledWithImplicitEnableRemoval = -61215;
+
+/**
+ * A gated clock has violated the handshaking protocol. If you are using
+ * external gated clocks, ensure that they follow the required clock gating
+ * protocol. If you are generating your clocks internally, please contact
+ * National Instruments Technical Support.
+ */
+static const NiFpga_Status NiFpga_Status_GatedClockHandshakingViolation = -61216;
+
+/**
+ * The number of elements requested must be less than or equal to the number of
+ * unacquired elements left in the host memory DMA FIFO. There are currently
+ * fewer unacquired elements left in the FIFO than are being requested. Release
+ * some acquired elements before acquiring more elements.
+ */
+static const NiFpga_Status NiFpga_Status_ElementsNotPermissibleToBeAcquired = -61219;
+
+/**
+ * The operation could not be performed because the FPGA is in configuration or
+ * discovery mode. Wait for configuration or discovery to complete and retry
+ * your operation.
+ */
+static const NiFpga_Status NiFpga_Status_FpgaBusyConfiguration = -61252;
+
+/**
+ * LabVIEW FPGA does not support Close and Reset if Last Reference for bitfiles
+ * that do not support Reset. Pass the
+ * NiFpga_CloseAttribute_NoResetIfLastSession attribute to NiFpga_Close instead
+ * of 0.
+ */
+static const NiFpga_Status NiFpga_Status_CloseAndResetCalledWithResetNotSupported = -61253;
+
+/**
+ * An unexpected internal error occurred.
+ */
+static const NiFpga_Status NiFpga_Status_InternalError = -61499;
+
+/**
+ * The NI-RIO driver was unable to allocate memory for a FIFO. This can happen
+ * when the combined depth of all DMA FIFOs exceeds the maximum depth for the
+ * controller, or when the controller runs out of system memory. You may be able
+ * to reconfigure the controller with a greater maximum FIFO depth. For more
+ * information, refer to the NI KnowledgeBase article 65OF2ERQ.
+ */
+static const NiFpga_Status NiFpga_Status_TotalDmaFifoDepthExceeded = -63003;
+
+/**
+ * Access to the remote system was denied. Use MAX to check the Remote Device
+ * Access settings under Software>>NI-RIO>>NI-RIO Settings on the remote system.
+ */
+static const NiFpga_Status NiFpga_Status_AccessDenied = -63033;
+
+/**
+ * The NI-RIO software on the host is not compatible with the software on the
+ * target. Upgrade the NI-RIO software on the host in order to connect to this
+ * target.
+ */
+static const NiFpga_Status NiFpga_Status_HostVersionMismatch = -63038;
+
+/**
+ * A connection could not be established to the specified remote device. Ensure
+ * that the device is on and accessible over the network, that NI-RIO software
+ * is installed, and that the RIO server is running and properly configured.
+ */
+static const NiFpga_Status NiFpga_Status_RpcConnectionError = -63040;
+
+/**
+ * The RPC session is invalid. The target may have reset or been rebooted. Check
+ * the network connection and retry the operation.
+ */
+static const NiFpga_Status NiFpga_Status_RpcSessionError = -63043;
+
+/**
+ * The operation could not complete because another session is accessing the
+ * FIFO. Close the other session and retry.
+ */
+static const NiFpga_Status NiFpga_Status_FifoReserved = -63082;
+
+/**
+ * A Configure FIFO, Stop FIFO, Read FIFO, or Write FIFO function was called
+ * while the host had acquired elements of the FIFO. Release all acquired
+ * elements before configuring, stopping, reading, or writing.
+ */
+static const NiFpga_Status NiFpga_Status_FifoElementsCurrentlyAcquired = -63083;
+
+/**
+ * A function was called using a misaligned address. The address must be a
+ * multiple of the size of the datatype.
+ */
+static const NiFpga_Status NiFpga_Status_MisalignedAccess = -63084;
+
+/**
+ * The FPGA Read/Write Control Function is accessing a control or indicator
+ * with data that exceeds the maximum size supported on the current target.
+ * Refer to the hardware documentation for the limitations on data types for
+ * this target.
+ */
+static const NiFpga_Status NiFpga_Status_ControlOrIndicatorTooLarge = -63085;
+
+/**
+ * A valid .lvbitx bitfile is required. If you are using a valid .lvbitx
+ * bitfile, the bitfile may not be compatible with the software you are using.
+ * Determine which version of LabVIEW was used to make the bitfile, update your
+ * software to that version or later, and try again.
+ */
+static const NiFpga_Status NiFpga_Status_BitfileReadError = -63101;
+
+/**
+ * The specified signature does not match the signature of the bitfile. If the
+ * bitfile has been recompiled, regenerate the C API and rebuild the
+ * application.
+ */
+static const NiFpga_Status NiFpga_Status_SignatureMismatch = -63106;
+
+/**
+ * The bitfile you are trying to use is incompatible with the version
+ * of NI-RIO installed on the target and/or host. Update the version
+ * of NI-RIO on the target and/or host to the same version (or later)
+ * used to compile the bitfile. Alternatively, recompile the bitfile
+ * with the same version of NI-RIO that is currently installed on the
+ * target and/or host.
+ */
+static const NiFpga_Status NiFpga_Status_IncompatibleBitfile = -63107;
+
+/**
+ * A hardware failure has occurred. The operation could not be completed as
+ * specified.
+ */
+static const NiFpga_Status NiFpga_Status_HardwareFault = -63150;
+
+/**
+ * Either the supplied resource name is invalid as a RIO resource name, or the
+ * device was not found. Use MAX to find the proper resource name for the
+ * intended device.
+ */
+static const NiFpga_Status NiFpga_Status_InvalidResourceName = -63192;
+
+/**
+ * The requested feature is not supported.
+ */
+static const NiFpga_Status NiFpga_Status_FeatureNotSupported = -63193;
+
+/**
+ * The NI-RIO software on the target system is not compatible with this
+ * software. Upgrade the NI-RIO software on the target system.
+ */
+static const NiFpga_Status NiFpga_Status_VersionMismatch = -63194;
+
+/**
+ * The session is invalid or has been closed.
+ */
+static const NiFpga_Status NiFpga_Status_InvalidSession = -63195;
+
+/**
+ * The maximum number of open FPGA sessions has been reached. Close some open
+ * sessions.
+ */
+static const NiFpga_Status NiFpga_Status_OutOfHandles = -63198;
+
+/**
+ * Tests whether a status is an error.
+ *
+ * @param status status to check for an error
+ * @return whether the status was an error
+ */
+static NiFpga_Inline NiFpga_Bool NiFpga_IsError(const NiFpga_Status status)
+{
+   return status < NiFpga_Status_Success ? NiFpga_True : NiFpga_False;
+}
+
+/**
+ * Tests whether a status is not an error. Success and warnings are not errors.
+ *
+ * @param status status to check for an error
+ * @return whether the status was a success or warning
+ */
+static NiFpga_Inline NiFpga_Bool NiFpga_IsNotError(const NiFpga_Status status)
+{
+   return status >= NiFpga_Status_Success ? NiFpga_True : NiFpga_False;
+}
+
+/**
+ * Conditionally sets the status to a new value. The previous status is
+ * preserved unless the new status is more of an error, which means that
+ * warnings and errors overwrite successes, and errors overwrite warnings. New
+ * errors do not overwrite older errors, and new warnings do not overwrite
+ * older warnings.
+ *
+ * @param status status to conditionally set
+ * @param newStatus new status value that may be set
+ * @return the resulting status
+ */
+static NiFpga_Inline NiFpga_Status NiFpga_MergeStatus(
+                                               NiFpga_Status* const status,
+                                               const NiFpga_Status  newStatus)
+{
+   if (!status)
+      return NiFpga_Status_InvalidParameter;
+   if (NiFpga_IsNotError(*status)
+   &&  (*status == NiFpga_Status_Success || NiFpga_IsError(newStatus)))
+      *status = newStatus;
+   return *status;
+}
+
+/**
+ * This macro evaluates the expression only if the status is not an error. The
+ * expression must evaluate to an NiFpga_Status, such as a call to any NiFpga_*
+ * function, because the status will be set to the returned status if the
+ * expression is evaluated.
+ *
+ * You can use this macro to mimic status chaining in LabVIEW, where the status
+ * does not have to be explicitly checked after each call. Such code may look
+ * like the following example.
+ *
+ *    NiFpga_Status status = NiFpga_Status_Success;
+ *    NiFpga_IfIsNotError(status, NiFpga_WriteU32(...));
+ *    NiFpga_IfIsNotError(status, NiFpga_WriteU32(...));
+ *    NiFpga_IfIsNotError(status, NiFpga_WriteU32(...));
+ *
+ * @param status status to check for an error
+ * @param expression expression to call if the incoming status is not an error
+ */
+#define NiFpga_IfIsNotError(status, expression) \
+   if (NiFpga_IsNotError(status)) \
+      NiFpga_MergeStatus(&status, (expression)); \
+
+/**
+ * You must call this function before all other function calls. This function
+ * loads the NiFpga library so that all the other functions will work. If this
+ * function succeeds, you must call NiFpga_Finalize after all other function
+ * calls.
+ *
+ * @warning This function is not thread safe.
+ *
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_Initialize(void);
+
+/**
+ * You must call this function after all other function calls if
+ * NiFpga_Initialize succeeds. This function unloads the NiFpga library.
+ *
+ * @warning This function is not thread safe.
+ *
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_Finalize(void);
+
+/**
+ * A handle to an FPGA session.
+ */
+typedef uint32_t NiFpga_Session;
+
+/**
+ * Attributes that NiFpga_Open accepts.
+ */
+typedef enum
+{
+   NiFpga_OpenAttribute_NoRun = 1
+} NiFpga_OpenAttribute;
+
+/**
+ * Opens a session to the FPGA. This call ensures that the contents of the
+ * bitfile are programmed to the FPGA. The FPGA runs unless the
+ * NiFpga_OpenAttribute_NoRun attribute is used.
+ *
+ * Because different operating systems have different default current working
+ * directories for applications, you must pass an absolute path for the bitfile
+ * parameter. If you pass only the filename instead of an absolute path, the
+ * operating system may not be able to locate the bitfile. For example, the
+ * default current working directories are C:\ni-rt\system\ for Phar Lap ETS and
+ * /c/ for VxWorks. Because the generated *_Bitfile constant is a #define to a
+ * string literal, you can use C/C++ string-literal concatenation to form an
+ * absolute path. For example, if the bitfile is in the root directory of a
+ * Phar Lap ETS system, pass the following for the bitfile parameter.
+ *
+ *    "C:\\" NiFpga_MyApplication_Bitfile
+ *
+ * @param bitfile path to the bitfile
+ * @param signature signature of the bitfile
+ * @param resource RIO resource string to open ("RIO0" or "rio://mysystem/RIO")
+ * @param attribute bitwise OR of any NiFpga_OpenAttributes, or 0
+ * @param session outputs the session handle, which must be closed when no
+ *                longer needed
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_Open(const char*     bitfile,
+                          const char*     signature,
+                          const char*     resource,
+                          uint32_t        attribute,
+                          NiFpga_Session* session);
+
+/**
+ * Attributes that NiFpga_Close accepts.
+ */
+typedef enum
+{
+   NiFpga_CloseAttribute_NoResetIfLastSession = 1
+} NiFpga_CloseAttribute;
+
+/**
+ * Closes the session to the FPGA. The FPGA resets unless either another session
+ * is still open or you use the NiFpga_CloseAttribute_NoResetIfLastSession
+ * attribute.
+ *
+ * @param session handle to a currently open session
+ * @param attribute bitwise OR of any NiFpga_CloseAttributes, or 0
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_Close(NiFpga_Session session,
+                           uint32_t       attribute);
+
+/**
+ * Attributes that NiFpga_Run accepts.
+ */
+typedef enum
+{
+   NiFpga_RunAttribute_WaitUntilDone = 1
+} NiFpga_RunAttribute;
+
+/**
+ * Runs the FPGA VI on the target. If you use NiFpga_RunAttribute_WaitUntilDone,
+ * NiFpga_Run blocks the thread until the FPGA finishes running.
+ *
+ * @param session handle to a currently open session
+ * @param attribute bitwise OR of any NiFpga_RunAttributes, or 0
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_Run(NiFpga_Session session,
+                         uint32_t       attribute);
+
+/**
+ * Aborts the FPGA VI.
+ *
+ * @param session handle to a currently open session
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_Abort(NiFpga_Session session);
+
+/**
+ * Resets the FPGA VI.
+ *
+ * @param session handle to a currently open session
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_Reset(NiFpga_Session session);
+
+/**
+ * Re-downloads the FPGA bitstream to the target.
+ *
+ * @param session handle to a currently open session
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_Download(NiFpga_Session session);
+
+/**
+ * Reads a boolean value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadBool(NiFpga_Session session,
+                              uint32_t       indicator,
+                              NiFpga_Bool*   value);
+
+/**
+ * Reads a signed 8-bit integer value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadI8(NiFpga_Session session,
+                            uint32_t       indicator,
+                            int8_t*        value);
+
+/**
+ * Reads an unsigned 8-bit integer value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadU8(NiFpga_Session session,
+                            uint32_t       indicator,
+                            uint8_t*       value);
+
+/**
+ * Reads a signed 16-bit integer value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadI16(NiFpga_Session session,
+                             uint32_t       indicator,
+                             int16_t*       value);
+
+/**
+ * Reads an unsigned 16-bit integer value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadU16(NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint16_t*      value);
+
+/**
+ * Reads a signed 32-bit integer value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadI32(NiFpga_Session session,
+                             uint32_t       indicator,
+                             int32_t*       value);
+
+/**
+ * Reads an unsigned 32-bit integer value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadU32(NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint32_t*      value);
+
+/**
+ * Reads a signed 64-bit integer value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadI64(NiFpga_Session session,
+                             uint32_t       indicator,
+                             int64_t*       value);
+
+/**
+ * Reads an unsigned 64-bit integer value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadU64(NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint64_t*      value);
+
+/**
+ * Reads a single-precision floating-point value from a given indicator or
+ * control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadSgl(NiFpga_Session session,
+                             uint32_t       indicator,
+                             float*         value);
+
+/**
+ * Reads a double-precision floating-point value from a given indicator or
+ * control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadDbl(NiFpga_Session session,
+                             uint32_t       indicator,
+                             double*        value);
+
+/**
+ * Writes a boolean value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteBool(NiFpga_Session session,
+                               uint32_t       control,
+                               NiFpga_Bool    value);
+
+/**
+ * Writes a signed 8-bit integer value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteI8(NiFpga_Session session,
+                             uint32_t       control,
+                             int8_t         value);
+
+/**
+ * Writes an unsigned 8-bit integer value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteU8(NiFpga_Session session,
+                             uint32_t       control,
+                             uint8_t        value);
+
+/**
+ * Writes a signed 16-bit integer value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteI16(NiFpga_Session session,
+                              uint32_t       control,
+                              int16_t        value);
+
+/**
+ * Writes an unsigned 16-bit integer value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteU16(NiFpga_Session session,
+                              uint32_t       control,
+                              uint16_t       value);
+
+/**
+ * Writes a signed 32-bit integer value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteI32(NiFpga_Session session,
+                              uint32_t       control,
+                              int32_t        value);
+
+/**
+ * Writes an unsigned 32-bit integer value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteU32(NiFpga_Session session,
+                              uint32_t       control,
+                              uint32_t       value);
+
+/**
+ * Writes a signed 64-bit integer value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteI64(NiFpga_Session session,
+                              uint32_t       control,
+                              int64_t        value);
+
+/**
+ * Writes an unsigned 64-bit integer value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteU64(NiFpga_Session session,
+                              uint32_t       control,
+                              uint64_t       value);
+
+/**
+ * Writes a single-precision floating-point value to a given control or
+ * indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteSgl(NiFpga_Session session,
+                              uint32_t       control,
+                              float          value);
+
+/**
+ * Writes a double-precision floating-point value to a given control or
+ * indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteDbl(NiFpga_Session session,
+                              uint32_t       control,
+                              double         value);
+
+/**
+ * Reads an entire array of boolean values from a given array indicator or
+ * control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayBool(NiFpga_Session session,
+                                   uint32_t       indicator,
+                                   NiFpga_Bool*   array,
+                                   size_t         size);
+
+/**
+ * Reads an entire array of signed 8-bit integer values from a given array
+ * indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayI8(NiFpga_Session session,
+                                 uint32_t       indicator,
+                                 int8_t*        array,
+                                 size_t         size);
+
+/**
+ * Reads an entire array of unsigned 8-bit integer values from a given array
+ * indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayU8(NiFpga_Session session,
+                                 uint32_t       indicator,
+                                 uint8_t*       array,
+                                 size_t         size);
+
+/**
+ * Reads an entire array of signed 16-bit integer values from a given array
+ * indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayI16(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int16_t*       array,
+                                  size_t         size);
+
+/**
+ * Reads an entire array of unsigned 16-bit integer values from a given array
+ * indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayU16(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint16_t*      array,
+                                  size_t         size);
+
+/**
+ * Reads an entire array of signed 32-bit integer values from a given array
+ * indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayI32(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int32_t*       array,
+                                  size_t         size);
+
+/**
+ * Reads an entire array of unsigned 32-bit integer values from a given array
+ * indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayU32(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint32_t*      array,
+                                  size_t         size);
+
+/**
+ * Reads an entire array of signed 64-bit integer values from a given array
+ * indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayI64(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int64_t*       array,
+                                  size_t         size);
+
+/**
+ * Reads an entire array of unsigned 64-bit integer values from a given array
+ * indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayU64(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint64_t*      array,
+                                  size_t         size);
+
+/**
+ * Reads an entire array of single-precision floating-point values from a
+ * given array indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArraySgl(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  float*         array,
+                                  size_t         size);
+
+/**
+ * Reads an entire array of double-precision floating-point values from a
+ * given array indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayDbl(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  double*        array,
+                                  size_t         size);
+
+/**
+ * Writes an entire array of boolean values to a given array control or
+ * indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayBool(NiFpga_Session     session,
+                                    uint32_t           control,
+                                    const NiFpga_Bool* array,
+                                    size_t             size);
+
+/**
+ * Writes an entire array of signed 8-bit integer values to a given array
+ * control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayI8(NiFpga_Session session,
+                                  uint32_t       control,
+                                  const int8_t*  array,
+                                  size_t         size);
+
+/**
+ * Writes an entire array of unsigned 8-bit integer values to a given array
+ * control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayU8(NiFpga_Session session,
+                                  uint32_t       control,
+                                  const uint8_t* array,
+                                  size_t         size);
+
+/**
+ * Writes an entire array of signed 16-bit integer values to a given array
+ * control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayI16(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int16_t* array,
+                                   size_t         size);
+
+/**
+ * Writes an entire array of unsigned 16-bit integer values to a given array
+ * control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayU16(NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint16_t* array,
+                                   size_t          size);
+
+/**
+ * Writes an entire array of signed 32-bit integer values to a given array
+ * control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayI32(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int32_t* array,
+                                   size_t         size);
+
+/**
+ * Writes an entire array of unsigned 32-bit integer values to a given array
+ * control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayU32(NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint32_t* array,
+                                   size_t          size);
+
+/**
+ * Writes an entire array of signed 64-bit integer values to a given array
+ * control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayI64(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int64_t* array,
+                                   size_t         size);
+
+/**
+ * Writes an entire array of unsigned 64-bit integer values to a given array
+ * control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayU64(NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint64_t* array,
+                                   size_t          size);
+
+/**
+ * Writes an entire array of single-precision floating-point values to a given
+ * array control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArraySgl(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const float*   array,
+                                   size_t         size);
+
+/**
+ * Writes an entire array of double-precision floating-point values to a given
+ * array control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayDbl(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const double*  array,
+                                   size_t         size);
+
+/**
+ * Enumeration of all 32 possible IRQs. Multiple IRQs can be bitwise ORed
+ * together like this:
+ *
+ *    NiFpga_Irq_3 | NiFpga_Irq_23
+ */
+typedef enum
+{
+   NiFpga_Irq_0  = 1 << 0,
+   NiFpga_Irq_1  = 1 << 1,
+   NiFpga_Irq_2  = 1 << 2,
+   NiFpga_Irq_3  = 1 << 3,
+   NiFpga_Irq_4  = 1 << 4,
+   NiFpga_Irq_5  = 1 << 5,
+   NiFpga_Irq_6  = 1 << 6,
+   NiFpga_Irq_7  = 1 << 7,
+   NiFpga_Irq_8  = 1 << 8,
+   NiFpga_Irq_9  = 1 << 9,
+   NiFpga_Irq_10 = 1 << 10,
+   NiFpga_Irq_11 = 1 << 11,
+   NiFpga_Irq_12 = 1 << 12,
+   NiFpga_Irq_13 = 1 << 13,
+   NiFpga_Irq_14 = 1 << 14,
+   NiFpga_Irq_15 = 1 << 15,
+   NiFpga_Irq_16 = 1 << 16,
+   NiFpga_Irq_17 = 1 << 17,
+   NiFpga_Irq_18 = 1 << 18,
+   NiFpga_Irq_19 = 1 << 19,
+   NiFpga_Irq_20 = 1 << 20,
+   NiFpga_Irq_21 = 1 << 21,
+   NiFpga_Irq_22 = 1 << 22,
+   NiFpga_Irq_23 = 1 << 23,
+   NiFpga_Irq_24 = 1 << 24,
+   NiFpga_Irq_25 = 1 << 25,
+   NiFpga_Irq_26 = 1 << 26,
+   NiFpga_Irq_27 = 1 << 27,
+   NiFpga_Irq_28 = 1 << 28,
+   NiFpga_Irq_29 = 1 << 29,
+   NiFpga_Irq_30 = 1 << 30,
+   NiFpga_Irq_31 = 1U << 31
+} NiFpga_Irq;
+
+/**
+ * Represents an infinite timeout.
+ */
+static const uint32_t NiFpga_InfiniteTimeout = 0xFFFFFFFF;
+
+/**
+ * See NiFpga_ReserveIrqContext for more information.
+ */
+typedef void* NiFpga_IrqContext;
+
+/**
+ * IRQ contexts are single-threaded; only one thread can wait with a
+ * particular context at any given time. To minimize jitter when first
+ * waiting on IRQs, reserve as many contexts as the application
+ * requires.
+ *
+ * If a context is successfully reserved (the returned status is not an error),
+ * it must be unreserved later. Otherwise a memory leak will occur.
+ *
+ * @param session handle to a currently open session
+ * @param context outputs the IRQ context
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReserveIrqContext(NiFpga_Session     session,
+                                       NiFpga_IrqContext* context);
+
+/**
+ * Unreserves an IRQ context obtained from NiFpga_ReserveIrqContext.
+ *
+ * @param session handle to a currently open session
+ * @param context IRQ context to unreserve
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_UnreserveIrqContext(NiFpga_Session    session,
+                                         NiFpga_IrqContext context);
+
+/**
+ * This is a blocking function that stops the calling thread until the
+ * FPGA asserts any IRQ in the irqs parameter, or until the function
+ * call times out.  Before calling this function, use
+ * NiFpga_ReserveIrqContext to reserve an IRQ context. No other
+ * threads can use the same context when this function is called.
+ *
+ * You can use the irqsAsserted parameter to determine which IRQs were asserted
+ * for each function call.
+ *
+ * @param session handle to a currently open session
+ * @param context IRQ context with which to wait
+ * @param irqs bitwise OR of NiFpga_Irqs
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param irqsAsserted if non-NULL, outputs bitwise OR of IRQs that were
+ *                     asserted
+ * @param timedOut if non-NULL, outputs whether the timeout expired
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WaitOnIrqs(NiFpga_Session    session,
+                                NiFpga_IrqContext context,
+                                uint32_t          irqs,
+                                uint32_t          timeout,
+                                uint32_t*         irqsAsserted,
+                                NiFpga_Bool*      timedOut);
+
+/**
+ * Acknowledges an IRQ or set of IRQs.
+ *
+ * @param session handle to a currently open session
+ * @param irqs bitwise OR of NiFpga_Irqs
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcknowledgeIrqs(NiFpga_Session session,
+                                     uint32_t       irqs);
+
+/**
+ * Specifies the depth of the host memory part of the DMA FIFO. This method is
+ * optional. In order to see the actual depth configured, use
+ * NiFpga_ConfigureFifo2.
+ *
+ * @param session handle to a currently open session
+ * @param fifo FIFO to configure
+ * @param depth requested number of elements in the host memory part of the
+ *              DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ConfigureFifo(NiFpga_Session session,
+                                   uint32_t       fifo,
+                                   size_t         depth);
+
+/**
+ * Specifies the depth of the host memory part of the DMA FIFO. This method is
+ * optional.
+ *
+ * @param session handle to a currently open session
+ * @param fifo FIFO to configure
+ * @param requestedDepth requested number of elements in the host memory part
+ *                       of the DMA FIFO
+ * @param actualDepth if non-NULL, outputs the actual number of elements in the
+ *                    host memory part of the DMA FIFO, which may be more than
+ *                    the requested number
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ConfigureFifo2(NiFpga_Session session,
+                                    uint32_t       fifo,
+                                    size_t         requestedDepth,
+                                    size_t*        actualDepth);
+
+/**
+ * Starts a FIFO. This method is optional.
+ *
+ * @param session handle to a currently open session
+ * @param fifo FIFO to start
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_StartFifo(NiFpga_Session session,
+                               uint32_t       fifo);
+
+/**
+ * Stops a FIFO. This method is optional.
+ *
+ * @param session handle to a currently open session
+ * @param fifo FIFO to stop
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_StopFifo(NiFpga_Session session,
+                              uint32_t       fifo);
+
+/**
+ * Reads from a target-to-host FIFO of booleans.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoBool(NiFpga_Session session,
+                                  uint32_t       fifo,
+                                  NiFpga_Bool*   data,
+                                  size_t         numberOfElements,
+                                  uint32_t       timeout,
+                                  size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of signed 8-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoI8(NiFpga_Session session,
+                                uint32_t       fifo,
+                                int8_t*        data,
+                                size_t         numberOfElements,
+                                uint32_t       timeout,
+                                size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of unsigned 8-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoU8(NiFpga_Session session,
+                                uint32_t       fifo,
+                                uint8_t*       data,
+                                size_t         numberOfElements,
+                                uint32_t       timeout,
+                                size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of signed 16-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoI16(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int16_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of unsigned 16-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoU16(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint16_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of signed 32-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoI32(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int32_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of unsigned 32-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoU32(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint32_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of signed 64-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoI64(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int64_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of unsigned 64-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoU64(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint64_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of single-precision floating-point values.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoSgl(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 float*         data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of double-precision floating-point values.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoDbl(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 double*        data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of booleans.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoBool(NiFpga_Session     session,
+                                   uint32_t           fifo,
+                                   const NiFpga_Bool* data,
+                                   size_t             numberOfElements,
+                                   uint32_t           timeout,
+                                   size_t*            emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of signed 8-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoI8(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int8_t*  data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of unsigned 8-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoU8(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const uint8_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of signed 16-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoI16(NiFpga_Session session,
+                                  uint32_t       fifo,
+                                  const int16_t* data,
+                                  size_t         numberOfElements,
+                                  uint32_t       timeout,
+                                  size_t*        emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of unsigned 16-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoU16(NiFpga_Session  session,
+                                  uint32_t        fifo,
+                                  const uint16_t* data,
+                                  size_t          numberOfElements,
+                                  uint32_t        timeout,
+                                  size_t*         emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of signed 32-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoI32(NiFpga_Session session,
+                                  uint32_t       fifo,
+                                  const int32_t* data,
+                                  size_t         numberOfElements,
+                                  uint32_t       timeout,
+                                  size_t*        emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of unsigned 32-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoU32(NiFpga_Session  session,
+                                  uint32_t        fifo,
+                                  const uint32_t* data,
+                                  size_t          numberOfElements,
+                                  uint32_t        timeout,
+                                  size_t*         emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of signed 64-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoI64(NiFpga_Session session,
+                                  uint32_t       fifo,
+                                  const int64_t* data,
+                                  size_t         numberOfElements,
+                                  uint32_t       timeout,
+                                  size_t*        emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of unsigned 64-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoU64(NiFpga_Session  session,
+                                  uint32_t        fifo,
+                                  const uint64_t* data,
+                                  size_t          numberOfElements,
+                                  uint32_t        timeout,
+                                  size_t*         emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of single-precision floating-point values.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoSgl(NiFpga_Session session,
+                                  uint32_t       fifo,
+                                  const float*   data,
+                                  size_t         numberOfElements,
+                                  uint32_t       timeout,
+                                  size_t*        emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of double-precision floating-point values.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoDbl(NiFpga_Session session,
+                                  uint32_t       fifo,
+                                  const double*  data,
+                                  size_t         numberOfElements,
+                                  uint32_t       timeout,
+                                  size_t*        emptyElementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of booleans.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsBool(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             NiFpga_Bool**  elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of signed 8-bit
+ * integers.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsI8(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             int8_t**       elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of unsigned 8-bit
+ * integers.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsU8(
+                                            NiFpga_Session  session,
+                                            uint32_t        fifo,
+                                            uint8_t**       elements,
+                                            size_t          elementsRequested,
+                                            uint32_t        timeout,
+                                            size_t*         elementsAcquired,
+                                            size_t*         elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of signed 16-bit
+ * integers.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsI16(
+                                            NiFpga_Session  session,
+                                            uint32_t        fifo,
+                                            int16_t**       elements,
+                                            size_t          elementsRequested,
+                                            uint32_t        timeout,
+                                            size_t*         elementsAcquired,
+                                            size_t*         elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of unsigned 16-bit
+ * integers.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsU16(
+                                           NiFpga_Session   session,
+                                           uint32_t         fifo,
+                                           uint16_t**       elements,
+                                           size_t           elementsRequested,
+                                           uint32_t         timeout,
+                                           size_t*          elementsAcquired,
+                                           size_t*          elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of signed 32-bit
+ * integers.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsI32(
+                                            NiFpga_Session  session,
+                                            uint32_t        fifo,
+                                            int32_t**       elements,
+                                            size_t          elementsRequested,
+                                            uint32_t        timeout,
+                                            size_t*         elementsAcquired,
+                                            size_t*         elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of unsigned 32-bit
+ * integers.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsU32(
+                                           NiFpga_Session   session,
+                                           uint32_t         fifo,
+                                           uint32_t**       elements,
+                                           size_t           elementsRequested,
+                                           uint32_t         timeout,
+                                           size_t*          elementsAcquired,
+                                           size_t*          elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of signed 64-bit
+ * integers.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsI64(
+                                            NiFpga_Session  session,
+                                            uint32_t        fifo,
+                                            int64_t**       elements,
+                                            size_t          elementsRequested,
+                                            uint32_t        timeout,
+                                            size_t*         elementsAcquired,
+                                            size_t*         elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of unsigned 64-bit
+ * integers.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsU64(
+                                           NiFpga_Session   session,
+                                           uint32_t         fifo,
+                                           uint64_t**       elements,
+                                           size_t           elementsRequested,
+                                           uint32_t         timeout,
+                                           size_t*          elementsAcquired,
+                                           size_t*          elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of single-precision
+ * floating-point values.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsSgl(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             float**        elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of double-precision
+ * floating-point values.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsDbl(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             double**       elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of booleans.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsBool(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             NiFpga_Bool**  elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of signed 8-bit
+ * integers.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI8(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             int8_t**       elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of unsigned 8-bit
+ * integers.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU8(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             uint8_t**      elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of signed 16-bit
+ * integers.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI16(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             int16_t**      elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of unsigned 16-bit
+ * integers.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU16(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             uint16_t**     elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of signed 32-bit
+ * integers.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI32(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             int32_t**      elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of unsigned 32-bit
+ * integers.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU32(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             uint32_t**     elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of signed 64-bit
+ * integers.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI64(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             int64_t**      elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of unsigned 64-bit
+ * integers.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU64(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             uint64_t**     elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of single-precision
+ * floating-point values.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsSgl(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             float**        elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of single-precision
+ * floating-point values.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsDbl(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             double**       elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Releases previously acquired FIFO elements.
+ *
+ * The FPGA target cannot read elements acquired by the host. Therefore, the
+ * host must release elements after acquiring them. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo FIFO from which to release elements
+ * @param elements number of elements to release
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReleaseFifoElements(NiFpga_Session session,
+                                         uint32_t       fifo,
+                                         size_t         elements);
+
+/**
+ * Gets an endpoint reference to a peer-to-peer FIFO.
+ *
+ * @param session handle to a currently open session
+ * @param fifo peer-to-peer FIFO
+ * @param endpoint Outputs the endpoint reference.
+ *                 The actual type is a nip2p_tEndpointHandle usable by
+ *                 the NI Peer-to-Peer Streaming C/C++ API.
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_GetPeerToPeerFifoEndpoint(NiFpga_Session session,
+                                               uint32_t       fifo,
+                                               uint32_t*      endpoint);
+
+#if NiFpga_Cpp
+}
+#endif
+
+#endif

--- a/aoldaq/src/aoldaq_core.c
+++ b/aoldaq/src/aoldaq_core.c
@@ -21,8 +21,13 @@ aoldaq_t *aoldaq_create_instance(aoldaq_args_t *p_args) {
         fpga_args.bitmap_width = p_args->bitmap_width;
         fpga_args.bitmap_height = p_args->bitmap_height;
     } else if(p_args->mode == AOLDAQ_MODE_REAL) {
-        fpga_args.mode = FPGA_MODE_RANDOM;
+        fpga_args.mode = FPGA_MODE_REAL;
+        fpga_args.nifpga_bitfile = p_args->nifpga_bitfile;
+        fpga_args.nifpga_resource = p_args->nifpga_resource;
+        fpga_args.nifpga_signature = p_args->nifpga_signature;
     }
+
+    fpga_args.n_channels = p_args->n_channels;
 
     p_state->p_fpga = fpga_init_session(&fpga_args);
 

--- a/aoldaq/src/aoldaq_core.c
+++ b/aoldaq/src/aoldaq_core.c
@@ -1,6 +1,5 @@
 /**
  * TODO:
- *  - add support for multiple channels
  */
 
 #include "aoldaq_core.h"
@@ -12,7 +11,20 @@ aoldaq_t *aoldaq_create_instance(aoldaq_args_t *p_args) {
     p_state->p_data_txs = malloc(sizeof(os_pipe_producer_t*) * p_args->n_channels);
     p_state->p_data_rxs = malloc(sizeof(os_pipe_consumer_t*) * p_args->n_channels);
 
-    p_state->p_fpgas = malloc(sizeof(fpga_t*) * p_args->n_channels);
+    fpga_args_t fpga_args;
+
+    if(p_args->mode == AOLDAQ_MODE_RANDOM) {
+        fpga_args.mode = FPGA_MODE_RANDOM;
+    } else if(p_args->mode == AOLDAQ_MODE_BITMAP) {
+        fpga_args.mode = FPGA_MODE_BITMAP;
+        fpga_args.bitmap_data = p_args->bitmap_data;
+        fpga_args.bitmap_width = p_args->bitmap_width;
+        fpga_args.bitmap_height = p_args->bitmap_height;
+    } else if(p_args->mode == AOLDAQ_MODE_REAL) {
+        fpga_args.mode = FPGA_MODE_RANDOM;
+    }
+
+    p_state->p_fpga = fpga_init_session(&fpga_args);
 
     p_state->daq_threads = malloc(sizeof(pthread_t) * p_args->n_channels);
     p_state->p_thread_args = malloc(sizeof(thread_args) * p_args->n_channels);
@@ -34,28 +46,6 @@ aoldaq_t *aoldaq_create_instance(aoldaq_args_t *p_args) {
         p_state->p_data_rxs[i] = os_pipe_alloc_consumer();
 
         os_pipe_create(p_state->p_data_rxs[i], p_state->p_data_txs[i]);
-
-        fpga_args_t args;
-
-        if(p_args->mode == AOLDAQ_MODE_RANDOM) {
-            args.mode = FPGA_MODE_RANDOM;
-        } else if(p_args->mode == AOLDAQ_MODE_BITMAP) {
-            args.mode = FPGA_MODE_BITMAP;
-            args.bitmap_data = p_args->bitmap_data;
-            args.bitmap_width = p_args->bitmap_width;
-            args.bitmap_height = p_args->bitmap_height;
-        } else if(p_args->mode == AOLDAQ_MODE_REAL) {
-            args.mode = FPGA_MODE_RANDOM;
-        }
-
-        fpga_t *p_fpga = fpga_init_session(&args);
-
-        if(!p_fpga) {
-            success = 0;
-            break;
-        }
-
-        p_state->p_fpgas[i] = p_fpga;
 
         thread_args targs = {
             .channel_idx = i,
@@ -88,9 +78,10 @@ aoldaq_t *aoldaq_create_instance(aoldaq_args_t *p_args) {
             os_pipe_free_producer(p_state->p_data_txs[j]);
         }
 
+        fpga_destroy(p_state->p_fpga);
+
         free(p_state->p_data_txs);
         free(p_state->p_data_rxs);
-        free(p_state->p_fpgas);
         free(p_state->daq_threads);
         free(p_state->p_thread_args);
         free(p_state);
@@ -118,9 +109,10 @@ void aoldaq_destroy_instance(aoldaq_t *p_state) {
         os_pipe_free_producer(p_state->p_data_txs[i]);
     }
 
+    fpga_destroy(p_state->p_fpga);
+
     free(p_state->p_data_txs);
     free(p_state->p_data_rxs);
-    free(p_state->p_fpgas);
     free(p_state->daq_threads);
     free(p_state->p_thread_args);
     free(p_state);
@@ -143,7 +135,8 @@ void *daq_thread_fun(void *p_args_raw) {
         if(!p_args->p_state->running) continue;
         
         uint32_t read = fpga_read(
-                p_args->p_state->p_fpgas[p_args->channel_idx], 
+                p_args->p_state->p_fpga,
+                p_args->channel_idx, 
                 back_buffer,
                 p_args->p_state->block_size
         );

--- a/aoldaq/src/aoldaq_core.h
+++ b/aoldaq/src/aoldaq_core.h
@@ -41,7 +41,7 @@ struct aoldaq_t {
     aoldaq_scan_params_t scan_params;
 
     // FPGA
-    fpga_t **p_fpgas;
+    fpga_t *p_fpga;
 
     thread_args *p_thread_args;
 };

--- a/aoldaq/src/fpga.c
+++ b/aoldaq/src/fpga.c
@@ -19,16 +19,48 @@ fpga_t *fpga_init_session(fpga_args_t *p_args) {
 
         memcpy(p_session->bitmap_data, p_args->bitmap_data, sizeof(uint32_t) *
                 p_session->bitmap_size);
+    } else if(p_session->mode == FPGA_MODE_REAL) {
+#ifdef AOL_USE_NIFPGA
+        p_session->nifpga_initialized = 0;
+
+        NiFpga_Status status;
+        // Initialize NiFpga
+        status = NiFpga_Initialize();
+
+        if(status != NiFpga_Status_Success) {
+            free(p_session);
+            return NULL;
+        }
+
+        status = NiFpga_Open(
+            p_args->nifpga_bitfile,
+            p_args->nifpga_signature,
+            p_args->nifpga_resource,
+            0, // TODO attributes?
+            &p_session->nifpga_session
+        );
+
+        if(status != NiFpga_Status_Success) {
+            free(p_session);
+            return NULL;
+        }
+#else
+        return NULL
+#endif
     }
 
     return p_session;
 }
 
 void fpga_destroy(fpga_t *p_session) {
+#ifdef AOL_USE_NIFPGA
+    NiFpga_Close(p_session->nifpga_session, 0);
+    NiFpga_Finalize();
+#endif
     free(p_session);
 }
 
-uint32_t fpga_read(fpga_t *p_session, uint32_t *buf, uint32_t n) {
+uint32_t fpga_read(fpga_t *p_session, uint8_t channel, uint32_t *buf, uint32_t n) {
     if(p_session->mode == FPGA_MODE_RANDOM) {
         fpga_gen_random(buf, n);
         return n;
@@ -53,12 +85,42 @@ uint32_t fpga_read(fpga_t *p_session, uint32_t *buf, uint32_t n) {
         p_session->bitmap_cursor += read;
 
         return n;
-    } else {
-        // TODO
+    } else if(p_session->mode == FPGA_MODE_REAL){
+        // Block while Matlab hasnt initialized the 
+        // FPGA yet.
+        while(!p_session->nifpga_initialized); 
 
+        NiFpga_Status status = NiFpga_ReadFifoU32(p_session->nifpga_session,
+                (uint32_t) channel,
+                buf,
+                n,
+                NiFpga_InfiniteTimeout,
+                NULL);
+
+        if(status != NiFpga_Status_Success) {
+            // TODO error handling?
+            return 0;
+        }
+
+        return n;
+    } else {
         return 0;
     }
 }
+
+#ifdef AOL_USE_NIFPGA
+NiFpga_Session fpga_get_nifpga(fpga_t *p_session) {
+    return p_session->nifpga_session;
+}
+
+void fpga_nifpga_flag_initialized(fpga_t *p_session) {
+    p_session->nifpga_initialized = 1;
+}
+
+void fpga_nifpga_flag_not_initialized(fpga_t *p_session) {
+    p_session->nifpga_initialized = 0;
+}
+#endif
 
 // Fill buf with random data
 static void fpga_gen_random(uint32_t *buf, uint32_t n) {

--- a/aoldaq/src/fpga.h
+++ b/aoldaq/src/fpga.h
@@ -3,6 +3,10 @@
 
 #include <stdint.h>
 
+#ifdef AOL_USE_NIFPGA
+#include "NiFpga.h"
+#endif
+
 // Functions related to low-level handling of the FPGA
 // TODO document this more
 
@@ -16,19 +20,35 @@ typedef enum {
 typedef struct {
     fpga_mode mode;
 
+    uint8_t n_channels;
+
     // For FPGA_MODE_BITMAP
     uint32_t* bitmap_data;
     uint32_t bitmap_size;
     uint32_t bitmap_cursor;
+
+#ifdef AOL_USE_NIFPGA
+    volatile char nifpga_initialized;
+    NiFpga_Session nifpga_session;
+#endif
 } fpga_t;
 
 typedef struct {
     fpga_mode mode;
 
+    uint8_t n_channels;
+
     // For FPGA_MODE_BITMAP
     uint32_t* bitmap_data;
     uint32_t bitmap_width;
     uint32_t bitmap_height;
+
+#ifdef AOL_USE_NIFPGA
+    // For FPGA_MODE_REAL
+    const char *nifpga_bitfile;
+    const char *nifpga_signature;
+    const char *nifpga_resource;
+#endif
 } fpga_args_t;
 
 /// Initializes a FPGA session.
@@ -36,7 +56,13 @@ fpga_t *fpga_init_session(fpga_args_t *p_args);
 
 void fpga_destroy(fpga_t *p_session);
 
-uint32_t fpga_read(fpga_t *p_session, uint32_t *buf, uint32_t n);
+uint32_t fpga_read(fpga_t *p_session, uint8_t channel, uint32_t *buf, uint32_t n);
+
+#ifdef AOL_USE_NIFPGA
+NiFpga_Session fpga_get_nifpga(fpga_t *p_session);
+void fpga_nifpga_flag_initialized(fpga_t *p_session);
+void fpga_nifpga_flag_not_initialized(fpga_t *p_session);
+#endif
 
 static void fpga_gen_random(uint32_t *buf, uint32_t n);
 

--- a/glviewer/src/main.c
+++ b/glviewer/src/main.c
@@ -4,6 +4,7 @@
 #include <GL/glew.h>
 #include <GL/freeglut.h>
 
+#define AOL_USE_NIFPGA
 #include <aoldaq/aoldaq.h>
 
 #define STB_IMAGE_IMPLEMENTATION
@@ -128,11 +129,15 @@ int main(int argc, char* argv[]) {
 
     aoldaq_args_t args = {
         .block_size = 200,
-        .mode = AOLDAQ_MODE_RANDOM,
+        .mode = AOLDAQ_MODE_REAL,
         .scan_params = scan_params,
-        .bitmap_data = bitmap_data,
-        .bitmap_width = WIDTH,
-        .bitmap_height = HEIGHT,
+        /*.bitmap_data = bitmap_data,*/
+        /*.bitmap_width = WIDTH,*/
+        /*.bitmap_height = HEIGHT,*/
+        .nifpga_bitfile = "/gimme/chocolate",
+        .nifpga_signature = "atotallycorrectsignature",
+        .nifpga_resource = "RIO/de/janeiro",
+        .n_channels = 2,
     };
 
     printf("Creating AOLDAQ instance...\n");

--- a/nifpga_shim/NiFpga.c
+++ b/nifpga_shim/NiFpga.c
@@ -1,0 +1,2479 @@
+/*
+ * FPGA Interface C API 17.0 source file.
+ *
+ * Copyright (c) 2017,
+ * National Instruments Corporation.
+ * All rights reserved.
+ */
+
+#include "NiFpga.h"
+
+/*
+ * Platform specific includes.
+ */
+#if NiFpga_Windows
+   #include <windows.h>
+#elif NiFpga_VxWorks
+   #include <vxWorks.h>
+   #include <symLib.h>
+   #include <loadLib.h>
+   #include <sysSymTbl.h>
+   MODULE_ID VxLoadLibraryFromPath(const char* path, int flags);
+   STATUS VxFreeLibrary(MODULE_ID library, int flags);
+#elif NiFpga_Linux || NiFpga_MacOsX
+   #include <stdlib.h>
+   #include <stdio.h>
+   #include <dlfcn.h>
+#else
+   #error
+#endif
+
+/*
+ * Platform specific defines.
+ */
+#if NiFpga_Windows
+   #define NiFpga_CCall   __cdecl
+   #define NiFpga_StdCall __stdcall
+#else
+   #define NiFpga_CCall
+   #define NiFpga_StdCall
+#endif
+
+/*
+ * Global library handle, or NULL if the library isn't loaded.
+ */
+#if NiFpga_Windows
+   static HMODULE NiFpga_library = NULL;
+#elif NiFpga_VxWorks
+   static MODULE_ID NiFpga_library = NULL;
+#elif NiFpga_Linux || NiFpga_MacOsX
+   static void* NiFpga_library = NULL;
+#else
+   #error
+#endif
+
+/*
+ * CVI Resource Tracking functions.
+ */
+#if NiFpga_Cvi && NiFpga_Windows
+#define NiFpga_CviResourceTracking 1
+
+static char* const NiFpga_cviResourceType = "FPGA Interface C API";
+
+typedef void* (NiFpga_CCall *NiFpga_AcquireCviResource)(void* resource,
+                                                        char* type,
+                                                        char* description,
+                                                        ...);
+
+static NiFpga_AcquireCviResource NiFpga_acquireCviResource = NULL;
+
+typedef void* (NiFpga_StdCall *NiFpga_ReleaseCviResource)(void* resource);
+
+static NiFpga_ReleaseCviResource NiFpga_releaseCviResource = NULL;
+#endif
+
+/*
+ * Session management functions.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_open)(
+                          const char*     path,
+                          const char*     signature,
+                          const char*     resource,
+                          uint32_t        attribute,
+                          NiFpga_Session* session) = NULL;
+
+NiFpga_Status NiFpga_Open(const char*     path,
+                          const char*     signature,
+                          const char*     resource,
+                          uint32_t        attribute,
+                          NiFpga_Session* session)
+{
+   const NiFpga_Status result = NiFpga_open
+                              ? NiFpga_open(path,
+                                            signature,
+                                            resource,
+                                            attribute,
+                                            session)
+                              : NiFpga_Status_ResourceNotInitialized;
+   #if NiFpga_CviResourceTracking
+      if (NiFpga_acquireCviResource
+      &&  NiFpga_IsNotError(result))
+         NiFpga_acquireCviResource((void*)*session,
+                                   NiFpga_cviResourceType,
+                                   "NiFpga_Session %#08x",
+                                   *session);
+   #endif
+   return result;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_close)(
+                           NiFpga_Session session,
+                           uint32_t       attribute) = NULL;
+
+NiFpga_Status NiFpga_Close(NiFpga_Session session,
+                           uint32_t       attribute)
+{
+   if (!NiFpga_close)
+      return NiFpga_Status_ResourceNotInitialized;
+   #if NiFpga_CviResourceTracking
+      if (NiFpga_releaseCviResource)
+         NiFpga_releaseCviResource((void*)session);
+   #endif
+   return NiFpga_close(session, attribute);
+}
+
+/*
+ * FPGA state functions.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_run)(
+                         NiFpga_Session session,
+                         uint32_t       attribute) = NULL;
+
+NiFpga_Status NiFpga_Run(NiFpga_Session session,
+                         uint32_t       attribute)
+{
+   return NiFpga_run
+        ? NiFpga_run(session, attribute)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_abort)(
+                           NiFpga_Session session) = NULL;
+
+NiFpga_Status NiFpga_Abort(NiFpga_Session session)
+{
+   return NiFpga_abort
+        ? NiFpga_abort(session)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_reset)(
+                           NiFpga_Session session) = NULL;
+
+NiFpga_Status NiFpga_Reset(NiFpga_Session session)
+{
+   return NiFpga_reset
+        ? NiFpga_reset(session)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_download)(
+                              NiFpga_Session session) = NULL;
+
+NiFpga_Status NiFpga_Download(NiFpga_Session session)
+{
+   return NiFpga_download
+        ? NiFpga_download(session)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/*
+ * Functions to read from scalar indicators and controls.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_readBool)(
+                              NiFpga_Session session,
+                              uint32_t       indicator,
+                              NiFpga_Bool*   value) = NULL;
+
+NiFpga_Status NiFpga_ReadBool(NiFpga_Session session,
+                              uint32_t       indicator,
+                              NiFpga_Bool*   value)
+{
+   return NiFpga_readBool
+        ? NiFpga_readBool(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readI8)(
+                            NiFpga_Session session,
+                            uint32_t       indicator,
+                            int8_t*        value) = NULL;
+
+NiFpga_Status NiFpga_ReadI8(NiFpga_Session session,
+                            uint32_t       indicator,
+                            int8_t*        value)
+{
+   return NiFpga_readI8
+        ? NiFpga_readI8(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readU8)(
+                            NiFpga_Session session,
+                            uint32_t       indicator,
+                            uint8_t*       value) = NULL;
+
+NiFpga_Status NiFpga_ReadU8(NiFpga_Session session,
+                            uint32_t       indicator,
+                            uint8_t*       value)
+{
+   return NiFpga_readU8
+        ? NiFpga_readU8(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readI16)(
+                             NiFpga_Session session,
+                             uint32_t       indicator,
+                             int16_t*       value) = NULL;
+
+NiFpga_Status NiFpga_ReadI16(NiFpga_Session session,
+                             uint32_t       indicator,
+                             int16_t*       value)
+{
+   return NiFpga_readI16
+        ? NiFpga_readI16(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readU16)(
+                             NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint16_t*      value) = NULL;
+
+NiFpga_Status NiFpga_ReadU16(NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint16_t*      value)
+{
+   return NiFpga_readU16
+        ? NiFpga_readU16(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readI32)(
+                             NiFpga_Session session,
+                             uint32_t       indicator,
+                             int32_t*       value) = NULL;
+
+NiFpga_Status NiFpga_ReadI32(NiFpga_Session session,
+                             uint32_t       indicator,
+                             int32_t*       value)
+{
+   return NiFpga_readI32
+        ? NiFpga_readI32(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readU32)(
+                             NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint32_t*      value) = NULL;
+
+NiFpga_Status NiFpga_ReadU32(NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint32_t*      value)
+{
+   return NiFpga_readU32
+        ? NiFpga_readU32(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readI64)(
+                             NiFpga_Session session,
+                             uint32_t       indicator,
+                             int64_t*       value) = NULL;
+
+NiFpga_Status NiFpga_ReadI64(NiFpga_Session session,
+                             uint32_t       indicator,
+                             int64_t*       value)
+{
+   return NiFpga_readI64
+        ? NiFpga_readI64(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readU64)(
+                             NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint64_t*      value) = NULL;
+
+NiFpga_Status NiFpga_ReadU64(NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint64_t*      value)
+{
+   return NiFpga_readU64
+        ? NiFpga_readU64(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readSgl)(
+                             NiFpga_Session session,
+                             uint32_t       indicator,
+                             float*         value) = NULL;
+
+NiFpga_Status NiFpga_ReadSgl(NiFpga_Session session,
+                             uint32_t       indicator,
+                             float*         value)
+{
+   return NiFpga_readSgl
+        ? NiFpga_readSgl(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readDbl)(
+                             NiFpga_Session session,
+                             uint32_t       indicator,
+                             double*        value) = NULL;
+
+NiFpga_Status NiFpga_ReadDbl(NiFpga_Session session,
+                             uint32_t       indicator,
+                             double*        value)
+{
+   return NiFpga_readDbl
+        ? NiFpga_readDbl(session, indicator, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/*
+ * Functions to write to scalar controls and indicators.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeBool)(
+                               NiFpga_Session session,
+                               uint32_t       control,
+                               NiFpga_Bool    value) = NULL;
+
+NiFpga_Status NiFpga_WriteBool(NiFpga_Session session,
+                               uint32_t       control,
+                               NiFpga_Bool    value)
+{
+   return NiFpga_writeBool
+        ? NiFpga_writeBool(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeI8)(
+                             NiFpga_Session session,
+                             uint32_t       control,
+                             int8_t         value) = NULL;
+
+NiFpga_Status NiFpga_WriteI8(NiFpga_Session session,
+                             uint32_t       control,
+                             int8_t         value)
+{
+   return NiFpga_writeI8
+        ? NiFpga_writeI8(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeU8)(
+                             NiFpga_Session session,
+                             uint32_t       control,
+                             uint8_t        value) = NULL;
+
+NiFpga_Status NiFpga_WriteU8(NiFpga_Session session,
+                             uint32_t       control,
+                             uint8_t        value)
+{
+   return NiFpga_writeU8
+        ? NiFpga_writeU8(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeI16)(
+                              NiFpga_Session session,
+                              uint32_t       control,
+                              int16_t        value) = NULL;
+
+NiFpga_Status NiFpga_WriteI16(NiFpga_Session session,
+                              uint32_t       control,
+                              int16_t        value)
+{
+   return NiFpga_writeI16
+        ? NiFpga_writeI16(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeU16)(
+                              NiFpga_Session session,
+                              uint32_t       control,
+                              uint16_t       value) = NULL;
+
+NiFpga_Status NiFpga_WriteU16(NiFpga_Session session,
+                              uint32_t       control,
+                              uint16_t       value)
+{
+   return NiFpga_writeU16
+        ? NiFpga_writeU16(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeI32)(
+                              NiFpga_Session session,
+                              uint32_t       control,
+                              int32_t        value) = NULL;
+
+NiFpga_Status NiFpga_WriteI32(NiFpga_Session session,
+                              uint32_t       control,
+                              int32_t        value)
+{
+   return NiFpga_writeI32
+        ? NiFpga_writeI32(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeU32)(
+                              NiFpga_Session session,
+                              uint32_t       control,
+                              uint32_t       value) = NULL;
+
+NiFpga_Status NiFpga_WriteU32(NiFpga_Session session,
+                              uint32_t       control,
+                              uint32_t       value)
+{
+   return NiFpga_writeU32
+        ? NiFpga_writeU32(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeI64)(
+                              NiFpga_Session session,
+                              uint32_t       control,
+                              int64_t        value) = NULL;
+
+NiFpga_Status NiFpga_WriteI64(NiFpga_Session session,
+                              uint32_t       control,
+                              int64_t        value)
+{
+   return NiFpga_writeI64
+        ? NiFpga_writeI64(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeU64)(
+                              NiFpga_Session session,
+                              uint32_t       control,
+                              uint64_t       value) = NULL;
+
+NiFpga_Status NiFpga_WriteU64(NiFpga_Session session,
+                              uint32_t       control,
+                              uint64_t       value)
+{
+   return NiFpga_writeU64
+        ? NiFpga_writeU64(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeSgl)(
+                              NiFpga_Session session,
+                              uint32_t       control,
+                              float          value) = NULL;
+
+NiFpga_Status NiFpga_WriteSgl(NiFpga_Session session,
+                              uint32_t       control,
+                              float          value)
+{
+   return NiFpga_writeSgl
+        ? NiFpga_writeSgl(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeDbl)(
+                              NiFpga_Session session,
+                              uint32_t       control,
+                              double         value) = NULL;
+
+NiFpga_Status NiFpga_WriteDbl(NiFpga_Session session,
+                              uint32_t       control,
+                              double         value)
+{
+   return NiFpga_writeDbl
+        ? NiFpga_writeDbl(session, control, value)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/*
+ * Functions to read from array indicators and controls.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayBool)(
+                                   NiFpga_Session session,
+                                   uint32_t       indicator,
+                                   NiFpga_Bool*   array,
+                                   size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayBool(NiFpga_Session session,
+                                   uint32_t       indicator,
+                                   NiFpga_Bool*   array,
+                                   size_t         size)
+{
+   return NiFpga_readArrayBool
+        ? NiFpga_readArrayBool(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayI8)(
+                                 NiFpga_Session session,
+                                 uint32_t       indicator,
+                                 int8_t*        array,
+                                 size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayI8(NiFpga_Session session,
+                                 uint32_t       indicator,
+                                 int8_t*        array,
+                                 size_t         size)
+{
+   return NiFpga_readArrayI8
+        ? NiFpga_readArrayI8(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayU8)(
+                                 NiFpga_Session session,
+                                 uint32_t       indicator,
+                                 uint8_t*       array,
+                                 size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayU8(NiFpga_Session session,
+                                 uint32_t       indicator,
+                                 uint8_t*       array,
+                                 size_t         size)
+{
+   return NiFpga_readArrayU8
+        ? NiFpga_readArrayU8(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayI16)(
+                                  NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int16_t*       array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayI16(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int16_t*       array,
+                                  size_t         size)
+{
+   return NiFpga_readArrayI16
+        ? NiFpga_readArrayI16(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayU16)(
+                                  NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint16_t*      array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayU16(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint16_t*      array,
+                                  size_t         size)
+{
+   return NiFpga_readArrayU16
+        ? NiFpga_readArrayU16(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayI32)(
+                                  NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int32_t*       array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayI32(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int32_t*       array,
+                                  size_t         size)
+{
+   return NiFpga_readArrayI32
+        ? NiFpga_readArrayI32(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayU32)(
+                                  NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint32_t*      array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayU32(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint32_t*      array,
+                                  size_t         size)
+{
+   return NiFpga_readArrayU32
+        ? NiFpga_readArrayU32(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayI64)(
+                                  NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int64_t*       array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayI64(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int64_t*       array,
+                                  size_t         size)
+{
+   return NiFpga_readArrayI64
+        ? NiFpga_readArrayI64(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayU64)(
+                                  NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint64_t*      array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayU64(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint64_t*      array,
+                                  size_t         size)
+{
+   return NiFpga_readArrayU64
+        ? NiFpga_readArrayU64(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArraySgl)(
+                                  NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  float*         array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArraySgl(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  float*         array,
+                                  size_t         size)
+{
+   return NiFpga_readArraySgl
+        ? NiFpga_readArraySgl(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readArrayDbl)(
+                                  NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  double*        array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_ReadArrayDbl(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  double*        array,
+                                  size_t         size)
+{
+   return NiFpga_readArrayDbl
+        ? NiFpga_readArrayDbl(session, indicator, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/*
+ * Functions to write to array controls and indicators.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayBool)(
+                                    NiFpga_Session     session,
+                                    uint32_t           control,
+                                    const NiFpga_Bool* array,
+                                    size_t             size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayBool(NiFpga_Session     session,
+                                    uint32_t           control,
+                                    const NiFpga_Bool* array,
+                                    size_t             size)
+{
+   return NiFpga_writeArrayBool
+        ? NiFpga_writeArrayBool(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayI8)(
+                                  NiFpga_Session session,
+                                  uint32_t       control,
+                                  const int8_t*  array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayI8(NiFpga_Session session,
+                                  uint32_t       control,
+                                  const int8_t*  array,
+                                  size_t         size)
+{
+   return NiFpga_writeArrayI8
+        ? NiFpga_writeArrayI8(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayU8)(
+                                  NiFpga_Session session,
+                                  uint32_t       control,
+                                  const uint8_t* array,
+                                  size_t         size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayU8(NiFpga_Session session,
+                                  uint32_t       control,
+                                  const uint8_t* array,
+                                  size_t         size)
+{
+   return NiFpga_writeArrayU8
+        ? NiFpga_writeArrayU8(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayI16)(
+                                   NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int16_t* array,
+                                   size_t         size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayI16(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int16_t* array,
+                                   size_t         size)
+{
+   return NiFpga_writeArrayI16
+        ? NiFpga_writeArrayI16(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayU16)(
+                                   NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint16_t* array,
+                                   size_t          size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayU16(NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint16_t* array,
+                                   size_t          size)
+{
+   return NiFpga_writeArrayU16
+        ? NiFpga_writeArrayU16(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayI32)(
+                                   NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int32_t* array,
+                                   size_t         size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayI32(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int32_t* array,
+                                   size_t         size)
+{
+   return NiFpga_writeArrayI32
+        ? NiFpga_writeArrayI32(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayU32)(
+                                   NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint32_t* array,
+                                   size_t          size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayU32(NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint32_t* array,
+                                   size_t          size)
+{
+   return NiFpga_writeArrayU32
+        ? NiFpga_writeArrayU32(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayI64)(
+                                   NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int64_t* array,
+                                   size_t         size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayI64(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int64_t* array,
+                                   size_t         size)
+{
+   return NiFpga_writeArrayI64
+        ? NiFpga_writeArrayI64(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayU64)(
+                                   NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint64_t* array,
+                                   size_t          size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayU64(NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint64_t* array,
+                                   size_t          size)
+{
+   return NiFpga_writeArrayU64
+        ? NiFpga_writeArrayU64(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArraySgl)(
+                                   NiFpga_Session session,
+                                   uint32_t       control,
+                                   const float*   array,
+                                   size_t         size) = NULL;
+
+NiFpga_Status NiFpga_WriteArraySgl(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const float*   array,
+                                   size_t         size)
+{
+   return NiFpga_writeArraySgl
+        ? NiFpga_writeArraySgl(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeArrayDbl)(
+                                   NiFpga_Session session,
+                                   uint32_t       control,
+                                   const double*  array,
+                                   size_t         size) = NULL;
+
+NiFpga_Status NiFpga_WriteArrayDbl(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const double*  array,
+                                   size_t         size)
+{
+   return NiFpga_writeArrayDbl
+        ? NiFpga_writeArrayDbl(session, control, array, size)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/*
+ * Interrupt functions.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_reserveIrqContext)(
+                                       NiFpga_Session     session,
+                                       NiFpga_IrqContext* context) = NULL;
+
+
+NiFpga_Status NiFpga_ReserveIrqContext(NiFpga_Session     session,
+                                       NiFpga_IrqContext* context)
+{
+   const NiFpga_Status result = NiFpga_reserveIrqContext
+                              ? NiFpga_reserveIrqContext(session, context)
+                              : NiFpga_Status_ResourceNotInitialized;
+   #if NiFpga_CviResourceTracking
+      if (NiFpga_acquireCviResource
+      &&  NiFpga_IsNotError(result))
+         NiFpga_acquireCviResource(*context,
+                                   NiFpga_cviResourceType,
+                                   "NiFpga_IrqContext 0x%p",
+                                   *context);
+   #endif
+   return result;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_unreserveIrqContext)(
+                                         NiFpga_Session    session,
+                                         NiFpga_IrqContext context) = NULL;
+
+
+NiFpga_Status NiFpga_UnreserveIrqContext(NiFpga_Session    session,
+                                         NiFpga_IrqContext context)
+{
+   if (!NiFpga_unreserveIrqContext)
+      return NiFpga_Status_ResourceNotInitialized;
+   #if NiFpga_CviResourceTracking
+      if (NiFpga_releaseCviResource)
+         NiFpga_releaseCviResource(context);
+   #endif
+   return NiFpga_unreserveIrqContext(session, context);
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_waitOnIrqs)(
+                                NiFpga_Session    session,
+                                NiFpga_IrqContext context,
+                                uint32_t          irqs,
+                                uint32_t          timeout,
+                                uint32_t*         irqsAsserted,
+                                NiFpga_Bool*      timedOut) = NULL;
+
+NiFpga_Status NiFpga_WaitOnIrqs(NiFpga_Session    session,
+                                NiFpga_IrqContext context,
+                                uint32_t          irqs,
+                                uint32_t          timeout,
+                                uint32_t*         irqsAsserted,
+                                NiFpga_Bool*      timedOut)
+{
+   return NiFpga_waitOnIrqs
+        ? NiFpga_waitOnIrqs(session,
+                            context,
+                            irqs,
+                            timeout,
+                            irqsAsserted,
+                            timedOut)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acknowledgeIrqs)(
+                                     NiFpga_Session session,
+                                     uint32_t       irqs) = NULL;
+
+NiFpga_Status NiFpga_AcknowledgeIrqs(NiFpga_Session session,
+                                     uint32_t       irqs)
+{
+   return NiFpga_acknowledgeIrqs
+        ? NiFpga_acknowledgeIrqs(session, irqs)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/*
+ * DMA FIFO state functions.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_configureFifo)(
+                                   NiFpga_Session session,
+                                   uint32_t       fifo,
+                                   size_t         depth) = NULL;
+
+NiFpga_Status NiFpga_ConfigureFifo(NiFpga_Session session,
+                                   uint32_t       fifo,
+                                   size_t         depth)
+{
+   return NiFpga_configureFifo
+        ? NiFpga_configureFifo(session, fifo, depth)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_configureFifo2)(
+                                   NiFpga_Session session,
+                                   uint32_t       fifo,
+                                   size_t         requestedDepth,
+                                   size_t*        actualDepth) = NULL;
+
+NiFpga_Status NiFpga_ConfigureFifo2(NiFpga_Session session,
+                                   uint32_t       fifo,
+                                   size_t         requestedDepth,
+                                   size_t*        actualDepth)
+{
+   return NiFpga_configureFifo2
+        ? NiFpga_configureFifo2(session, fifo, requestedDepth, actualDepth)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_startFifo)(
+                               NiFpga_Session session,
+                               uint32_t       fifo) = NULL;
+
+NiFpga_Status NiFpga_StartFifo(NiFpga_Session session,
+                               uint32_t       fifo)
+{
+   return NiFpga_startFifo
+        ? NiFpga_startFifo(session, fifo)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_stopFifo)(
+                              NiFpga_Session session,
+                              uint32_t       fifo) = NULL;
+
+NiFpga_Status NiFpga_StopFifo(NiFpga_Session session,
+                              uint32_t       fifo)
+{
+   return NiFpga_stopFifo
+        ? NiFpga_stopFifo(session, fifo)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/*
+ * Functions to read from target-to-host DMA FIFOs.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoBool)(
+                                  NiFpga_Session session,
+                                  uint32_t       fifo,
+                                  NiFpga_Bool*   data,
+                                  size_t         numberOfElements,
+                                  uint32_t       timeout,
+                                  size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoBool(NiFpga_Session session,
+                                  uint32_t       fifo,
+                                  NiFpga_Bool*   data,
+                                  size_t         numberOfElements,
+                                  uint32_t       timeout,
+                                  size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoBool
+        ? NiFpga_readFifoBool(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoI8)(
+                                NiFpga_Session session,
+                                uint32_t       fifo,
+                                int8_t*        data,
+                                size_t         numberOfElements,
+                                uint32_t       timeout,
+                                size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoI8(NiFpga_Session session,
+                                uint32_t       fifo,
+                                int8_t*        data,
+                                size_t         numberOfElements,
+                                uint32_t       timeout,
+                                size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoI8
+        ? NiFpga_readFifoI8(session,
+                            fifo,
+                            data,
+                            numberOfElements,
+                            timeout,
+                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoU8)(
+                                NiFpga_Session session,
+                                uint32_t       fifo,
+                                uint8_t*       data,
+                                size_t         numberOfElements,
+                                uint32_t       timeout,
+                                size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoU8(NiFpga_Session session,
+                                uint32_t       fifo,
+                                uint8_t*       data,
+                                size_t         numberOfElements,
+                                uint32_t       timeout,
+                                size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoU8
+        ? NiFpga_readFifoU8(session,
+                            fifo,
+                            data,
+                            numberOfElements,
+                            timeout,
+                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoI16)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int16_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoI16(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int16_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoI16
+        ? NiFpga_readFifoI16(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoU16)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint16_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoU16(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint16_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoU16
+        ? NiFpga_readFifoU16(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoI32)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int32_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoI32(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int32_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoI32
+        ? NiFpga_readFifoI32(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoU32)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint32_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoU32(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint32_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoU32
+        ? NiFpga_readFifoU32(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoI64)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int64_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoI64(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int64_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoI64
+        ? NiFpga_readFifoI64(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoU64)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint64_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoU64(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint64_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoU64
+        ? NiFpga_readFifoU64(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoSgl)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 float*         data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoSgl(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 float*         data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoSgl
+        ? NiFpga_readFifoSgl(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_readFifoDbl)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 double*        data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_ReadFifoDbl(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 double*        data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining)
+{
+   return NiFpga_readFifoDbl
+        ? NiFpga_readFifoDbl(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/*
+ * Functions to write to host-to-target DMA FIFOs.
+ */
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoBool)(
+                             NiFpga_Session     session,
+                             uint32_t           fifo,
+                             const NiFpga_Bool* data,
+                             size_t             numberOfElements,
+                             uint32_t           timeout,
+                             size_t*            emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoBool(
+                             NiFpga_Session     session,
+                             uint32_t           fifo,
+                             const NiFpga_Bool* data,
+                             size_t             numberOfElements,
+                             uint32_t           timeout,
+                             size_t*            emptyElementsRemaining)
+{
+   return NiFpga_writeFifoBool
+        ? NiFpga_writeFifoBool(session,
+                               fifo,
+                               data,
+                               numberOfElements,
+                               timeout,
+                               emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoI8)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int8_t*  data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoI8(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int8_t*  data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining)
+{
+   return NiFpga_writeFifoI8
+        ? NiFpga_writeFifoI8(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoU8)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const uint8_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoU8(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const uint8_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining)
+{
+   return NiFpga_writeFifoU8
+        ? NiFpga_writeFifoU8(session,
+                             fifo,
+                             data,
+                             numberOfElements,
+                             timeout,
+                             emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoI16)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int16_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoI16(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int16_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining)
+{
+   return NiFpga_writeFifoI16
+        ? NiFpga_writeFifoI16(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoU16)(
+                                NiFpga_Session  session,
+                                uint32_t        fifo,
+                                const uint16_t* data,
+                                size_t          numberOfElements,
+                                uint32_t        timeout,
+                                size_t*         emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoU16(
+                                NiFpga_Session  session,
+                                uint32_t        fifo,
+                                const uint16_t* data,
+                                size_t          numberOfElements,
+                                uint32_t        timeout,
+                                size_t*         emptyElementsRemaining)
+{
+   return NiFpga_writeFifoU16
+        ? NiFpga_writeFifoU16(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoI32)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int32_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoI32(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int32_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining)
+{
+   return NiFpga_writeFifoI32
+        ? NiFpga_writeFifoI32(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoU32)(
+                                NiFpga_Session  session,
+                                uint32_t        fifo,
+                                const uint32_t* data,
+                                size_t          numberOfElements,
+                                uint32_t        timeout,
+                                size_t*         emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoU32(
+                                NiFpga_Session  session,
+                                uint32_t        fifo,
+                                const uint32_t* data,
+                                size_t          numberOfElements,
+                                uint32_t        timeout,
+                                size_t*         emptyElementsRemaining)
+{
+   return NiFpga_writeFifoU32
+        ? NiFpga_writeFifoU32(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoI64)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int64_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoI64(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int64_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining)
+{
+   return NiFpga_writeFifoI64
+        ? NiFpga_writeFifoI64(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoU64)(
+                                NiFpga_Session  session,
+                                uint32_t        fifo,
+                                const uint64_t* data,
+                                size_t          numberOfElements,
+                                uint32_t        timeout,
+                                size_t*         emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoU64(
+                                NiFpga_Session  session,
+                                uint32_t        fifo,
+                                const uint64_t* data,
+                                size_t          numberOfElements,
+                                uint32_t        timeout,
+                                size_t*         emptyElementsRemaining)
+{
+   return NiFpga_writeFifoU64
+        ? NiFpga_writeFifoU64(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoSgl)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const float*   data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoSgl(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const float*   data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining)
+{
+   return NiFpga_writeFifoSgl
+        ? NiFpga_writeFifoSgl(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_writeFifoDbl)(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const double*  data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_WriteFifoDbl(
+                                 NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const double*  data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining)
+{
+   return NiFpga_writeFifoDbl
+        ? NiFpga_writeFifoDbl(session,
+                              fifo,
+                              data,
+                              numberOfElements,
+                              timeout,
+                              emptyElementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsBool)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      NiFpga_Bool**  elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsBool(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      NiFpga_Bool**  elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsBool
+        ? NiFpga_acquireFifoReadElementsBool(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsI8)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int8_t**       elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsI8(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int8_t**       elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsI8
+        ? NiFpga_acquireFifoReadElementsI8(session,
+                                           fifo,
+                                           elements,
+                                           elementsRequested,
+                                           timeout,
+                                           elementsAcquired,
+                                           elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsU8)(
+                                     NiFpga_Session  session,
+                                     uint32_t        fifo,
+                                     uint8_t**       elements,
+                                     size_t          elementsRequested,
+                                     uint32_t        timeout,
+                                     size_t*         elementsAcquired,
+                                     size_t*         elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsU8(
+                                     NiFpga_Session  session,
+                                     uint32_t        fifo,
+                                     uint8_t**       elements,
+                                     size_t          elementsRequested,
+                                     uint32_t        timeout,
+                                     size_t*         elementsAcquired,
+                                     size_t*         elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsU8
+        ? NiFpga_acquireFifoReadElementsU8(session,
+                                           fifo,
+                                           elements,
+                                           elementsRequested,
+                                           timeout,
+                                           elementsAcquired,
+                                           elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsI16)(
+                                     NiFpga_Session  session,
+                                     uint32_t        fifo,
+                                     int16_t**       elements,
+                                     size_t          elementsRequested,
+                                     uint32_t        timeout,
+                                     size_t*         elementsAcquired,
+                                     size_t*         elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsI16(
+                                     NiFpga_Session  session,
+                                     uint32_t        fifo,
+                                     int16_t**       elements,
+                                     size_t          elementsRequested,
+                                     uint32_t        timeout,
+                                     size_t*         elementsAcquired,
+                                     size_t*         elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsI16
+        ? NiFpga_acquireFifoReadElementsI16(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsU16)(
+                                    NiFpga_Session   session,
+                                    uint32_t         fifo,
+                                    uint16_t**       elements,
+                                    size_t           elementsRequested,
+                                    uint32_t         timeout,
+                                    size_t*          elementsAcquired,
+                                    size_t*          elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsU16(
+                                    NiFpga_Session   session,
+                                    uint32_t         fifo,
+                                    uint16_t**       elements,
+                                    size_t           elementsRequested,
+                                    uint32_t         timeout,
+                                    size_t*          elementsAcquired,
+                                    size_t*          elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsU16
+        ? NiFpga_acquireFifoReadElementsU16(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsI32)(
+                                     NiFpga_Session  session,
+                                     uint32_t        fifo,
+                                     int32_t**       elements,
+                                     size_t          elementsRequested,
+                                     uint32_t        timeout,
+                                     size_t*         elementsAcquired,
+                                     size_t*         elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsI32(
+                                     NiFpga_Session  session,
+                                     uint32_t        fifo,
+                                     int32_t**       elements,
+                                     size_t          elementsRequested,
+                                     uint32_t        timeout,
+                                     size_t*         elementsAcquired,
+                                     size_t*         elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsI32
+        ? NiFpga_acquireFifoReadElementsI32(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsU32)(
+                                    NiFpga_Session   session,
+                                    uint32_t         fifo,
+                                    uint32_t**       elements,
+                                    size_t           elementsRequested,
+                                    uint32_t         timeout,
+                                    size_t*          elementsAcquired,
+                                    size_t*          elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsU32(
+                                    NiFpga_Session   session,
+                                    uint32_t         fifo,
+                                    uint32_t**       elements,
+                                    size_t           elementsRequested,
+                                    uint32_t         timeout,
+                                    size_t*          elementsAcquired,
+                                    size_t*          elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsU32
+        ? NiFpga_acquireFifoReadElementsU32(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsI64)(
+                                     NiFpga_Session  session,
+                                     uint32_t        fifo,
+                                     int64_t**       elements,
+                                     size_t          elementsRequested,
+                                     uint32_t        timeout,
+                                     size_t*         elementsAcquired,
+                                     size_t*         elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsI64(
+                                     NiFpga_Session  session,
+                                     uint32_t        fifo,
+                                     int64_t**       elements,
+                                     size_t          elementsRequested,
+                                     uint32_t        timeout,
+                                     size_t*         elementsAcquired,
+                                     size_t*         elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsI64
+        ? NiFpga_acquireFifoReadElementsI64(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsU64)(
+                                    NiFpga_Session   session,
+                                    uint32_t         fifo,
+                                    uint64_t**       elements,
+                                    size_t           elementsRequested,
+                                    uint32_t         timeout,
+                                    size_t*          elementsAcquired,
+                                    size_t*          elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsU64(
+                                    NiFpga_Session   session,
+                                    uint32_t         fifo,
+                                    uint64_t**       elements,
+                                    size_t           elementsRequested,
+                                    uint32_t         timeout,
+                                    size_t*          elementsAcquired,
+                                    size_t*          elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsU64
+        ? NiFpga_acquireFifoReadElementsU64(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsSgl)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      float**        elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsSgl(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      float**        elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsSgl
+        ? NiFpga_acquireFifoReadElementsSgl(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoReadElementsDbl)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      double**       elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsDbl(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      double**       elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoReadElementsDbl
+        ? NiFpga_acquireFifoReadElementsDbl(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsBool)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      NiFpga_Bool**  elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsBool(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      NiFpga_Bool**  elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsBool
+        ? NiFpga_acquireFifoWriteElementsBool(session,
+                                              fifo,
+                                              elements,
+                                              elementsRequested,
+                                              timeout,
+                                              elementsAcquired,
+                                              elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsI8)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int8_t**       elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI8(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int8_t**       elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsI8
+        ? NiFpga_acquireFifoWriteElementsI8(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsU8)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      uint8_t**      elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU8(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      uint8_t**      elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsU8
+        ? NiFpga_acquireFifoWriteElementsU8(session,
+                                            fifo,
+                                            elements,
+                                            elementsRequested,
+                                            timeout,
+                                            elementsAcquired,
+                                            elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsI16)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int16_t**      elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI16(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int16_t**      elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsI16
+        ? NiFpga_acquireFifoWriteElementsI16(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsU16)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      uint16_t**     elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU16(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      uint16_t**     elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsU16
+        ? NiFpga_acquireFifoWriteElementsU16(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsI32)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int32_t**      elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI32(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int32_t**      elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsI32
+        ? NiFpga_acquireFifoWriteElementsI32(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsU32)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      uint32_t**     elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU32(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      uint32_t**     elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsU32
+        ? NiFpga_acquireFifoWriteElementsU32(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsI64)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int64_t**      elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI64(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      int64_t**      elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsI64
+        ? NiFpga_acquireFifoWriteElementsI64(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsU64)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      uint64_t**     elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU64(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      uint64_t**     elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsU64
+        ? NiFpga_acquireFifoWriteElementsU64(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsSgl)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      float**        elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsSgl(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      float**        elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsSgl
+        ? NiFpga_acquireFifoWriteElementsSgl(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_acquireFifoWriteElementsDbl)(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      double**       elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining) = NULL;
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsDbl(
+                                      NiFpga_Session session,
+                                      uint32_t       fifo,
+                                      double**       elements,
+                                      size_t         elementsRequested,
+                                      uint32_t       timeout,
+                                      size_t*        elementsAcquired,
+                                      size_t*        elementsRemaining)
+{
+   return NiFpga_acquireFifoWriteElementsDbl
+        ? NiFpga_acquireFifoWriteElementsDbl(session,
+                                             fifo,
+                                             elements,
+                                             elementsRequested,
+                                             timeout,
+                                             elementsAcquired,
+                                             elementsRemaining)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_releaseFifoElements)(
+                                         NiFpga_Session session,
+                                         uint32_t       fifo,
+                                         size_t         elements) = NULL;
+
+NiFpga_Status NiFpga_ReleaseFifoElements(NiFpga_Session session,
+                                         uint32_t       fifo,
+                                         size_t         elements)
+{
+   return NiFpga_releaseFifoElements
+        ? NiFpga_releaseFifoElements(session, fifo, elements)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_getPeerToPeerFifoEndpoint)(
+                                         NiFpga_Session session,
+                                         uint32_t       fifo,
+                                         uint32_t*      endpoint) = NULL;
+
+NiFpga_Status NiFpga_GetPeerToPeerFifoEndpoint(NiFpga_Session session,
+                                         uint32_t       fifo,
+                                         uint32_t*      endpoint)
+{
+   return NiFpga_getPeerToPeerFifoEndpoint
+        ? NiFpga_getPeerToPeerFifoEndpoint(session, fifo, endpoint)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_getBitfileContents)(
+                                        NiFpga_Session session,
+                                        const char**   contents) = NULL;
+
+NiFpga_Status NiFpga_GetBitfileContents(NiFpga_Session session,
+                                        const char**   contents)
+{
+   return NiFpga_getBitfileContents
+        ? NiFpga_getBitfileContents(session, contents)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+static NiFpga_Status (NiFpga_CCall *NiFpga_clientFunctionCall)(
+                                        NiFpga_Session session,
+                                        uint32_t group,
+                                        uint32_t functionId,
+                                        const void* inBuffer,
+                                        size_t inBufferSize,
+                                        void* outBuffer,
+                                        size_t outBufferSize) = NULL;
+
+NiFpga_Status NiFpga_ClientFunctionCall(NiFpga_Session session,
+                                        uint32_t group,
+                                        uint32_t functionId,
+                                        const void* inBuffer,
+                                        size_t inBufferSize,
+                                        void* outBuffer,
+                                        size_t outBufferSize)
+{
+   return NiFpga_clientFunctionCall
+        ? NiFpga_clientFunctionCall(session, group, functionId, inBuffer, inBufferSize, outBuffer, outBufferSize)
+        : NiFpga_Status_ResourceNotInitialized;
+}
+
+/**
+ * A type large enough to hold entry point function pointer.
+ */
+typedef NiFpga_Status (NiFpga_CCall *NiFpga_FunctionPointer)();
+
+/**
+ * A NULL-terminated array of all entry point functions.
+ */
+static const struct
+{
+   const char* const name;
+   NiFpga_FunctionPointer* const address;
+} NiFpga_functions[] =
+{
+   {"NiFpgaDll_Open",                (NiFpga_FunctionPointer*)&NiFpga_open},
+   {"NiFpgaDll_Close",               (NiFpga_FunctionPointer*)&NiFpga_close},
+   {"NiFpgaDll_Run",                 (NiFpga_FunctionPointer*)&NiFpga_run},
+   {"NiFpgaDll_Abort",               (NiFpga_FunctionPointer*)&NiFpga_abort},
+   {"NiFpgaDll_Reset",               (NiFpga_FunctionPointer*)&NiFpga_reset},
+   {"NiFpgaDll_Download",            (NiFpga_FunctionPointer*)&NiFpga_download},
+   {"NiFpgaDll_ReadBool",            (NiFpga_FunctionPointer*)&NiFpga_readBool},
+   {"NiFpgaDll_ReadI8",              (NiFpga_FunctionPointer*)&NiFpga_readI8},
+   {"NiFpgaDll_ReadU8",              (NiFpga_FunctionPointer*)&NiFpga_readU8},
+   {"NiFpgaDll_ReadI16",             (NiFpga_FunctionPointer*)&NiFpga_readI16},
+   {"NiFpgaDll_ReadU16",             (NiFpga_FunctionPointer*)&NiFpga_readU16},
+   {"NiFpgaDll_ReadI32",             (NiFpga_FunctionPointer*)&NiFpga_readI32},
+   {"NiFpgaDll_ReadU32",             (NiFpga_FunctionPointer*)&NiFpga_readU32},
+   {"NiFpgaDll_ReadI64",             (NiFpga_FunctionPointer*)&NiFpga_readI64},
+   {"NiFpgaDll_ReadU64",             (NiFpga_FunctionPointer*)&NiFpga_readU64},
+   {"NiFpgaDll_ReadSgl",             (NiFpga_FunctionPointer*)&NiFpga_readSgl},
+   {"NiFpgaDll_ReadDbl",             (NiFpga_FunctionPointer*)&NiFpga_readDbl},
+   {"NiFpgaDll_WriteBool",           (NiFpga_FunctionPointer*)&NiFpga_writeBool},
+   {"NiFpgaDll_WriteI8",             (NiFpga_FunctionPointer*)&NiFpga_writeI8},
+   {"NiFpgaDll_WriteU8",             (NiFpga_FunctionPointer*)&NiFpga_writeU8},
+   {"NiFpgaDll_WriteI16",            (NiFpga_FunctionPointer*)&NiFpga_writeI16},
+   {"NiFpgaDll_WriteU16",            (NiFpga_FunctionPointer*)&NiFpga_writeU16},
+   {"NiFpgaDll_WriteI32",            (NiFpga_FunctionPointer*)&NiFpga_writeI32},
+   {"NiFpgaDll_WriteU32",            (NiFpga_FunctionPointer*)&NiFpga_writeU32},
+   {"NiFpgaDll_WriteI64",            (NiFpga_FunctionPointer*)&NiFpga_writeI64},
+   {"NiFpgaDll_WriteU64",            (NiFpga_FunctionPointer*)&NiFpga_writeU64},
+   {"NiFpgaDll_WriteSgl",            (NiFpga_FunctionPointer*)&NiFpga_writeSgl},
+   {"NiFpgaDll_WriteDbl",            (NiFpga_FunctionPointer*)&NiFpga_writeDbl},
+   {"NiFpgaDll_ReadArrayBool",       (NiFpga_FunctionPointer*)&NiFpga_readArrayBool},
+   {"NiFpgaDll_ReadArrayI8",         (NiFpga_FunctionPointer*)&NiFpga_readArrayI8},
+   {"NiFpgaDll_ReadArrayU8",         (NiFpga_FunctionPointer*)&NiFpga_readArrayU8},
+   {"NiFpgaDll_ReadArrayI16",        (NiFpga_FunctionPointer*)&NiFpga_readArrayI16},
+   {"NiFpgaDll_ReadArrayU16",        (NiFpga_FunctionPointer*)&NiFpga_readArrayU16},
+   {"NiFpgaDll_ReadArrayI32",        (NiFpga_FunctionPointer*)&NiFpga_readArrayI32},
+   {"NiFpgaDll_ReadArrayU32",        (NiFpga_FunctionPointer*)&NiFpga_readArrayU32},
+   {"NiFpgaDll_ReadArrayI64",        (NiFpga_FunctionPointer*)&NiFpga_readArrayI64},
+   {"NiFpgaDll_ReadArrayU64",        (NiFpga_FunctionPointer*)&NiFpga_readArrayU64},
+   {"NiFpgaDll_ReadArraySgl",        (NiFpga_FunctionPointer*)&NiFpga_readArraySgl},
+   {"NiFpgaDll_ReadArrayDbl",        (NiFpga_FunctionPointer*)&NiFpga_readArrayDbl},
+   {"NiFpgaDll_WriteArrayBool",      (NiFpga_FunctionPointer*)&NiFpga_writeArrayBool},
+   {"NiFpgaDll_WriteArrayI8",        (NiFpga_FunctionPointer*)&NiFpga_writeArrayI8},
+   {"NiFpgaDll_WriteArrayU8",        (NiFpga_FunctionPointer*)&NiFpga_writeArrayU8},
+   {"NiFpgaDll_WriteArrayI16",       (NiFpga_FunctionPointer*)&NiFpga_writeArrayI16},
+   {"NiFpgaDll_WriteArrayU16",       (NiFpga_FunctionPointer*)&NiFpga_writeArrayU16},
+   {"NiFpgaDll_WriteArrayI32",       (NiFpga_FunctionPointer*)&NiFpga_writeArrayI32},
+   {"NiFpgaDll_WriteArrayU32",       (NiFpga_FunctionPointer*)&NiFpga_writeArrayU32},
+   {"NiFpgaDll_WriteArrayI64",       (NiFpga_FunctionPointer*)&NiFpga_writeArrayI64},
+   {"NiFpgaDll_WriteArrayU64",       (NiFpga_FunctionPointer*)&NiFpga_writeArrayU64},
+   {"NiFpgaDll_WriteArraySgl",       (NiFpga_FunctionPointer*)&NiFpga_writeArraySgl},
+   {"NiFpgaDll_WriteArrayDbl",       (NiFpga_FunctionPointer*)&NiFpga_writeArrayDbl},
+   {"NiFpgaDll_ReserveIrqContext",   (NiFpga_FunctionPointer*)&NiFpga_reserveIrqContext},
+   {"NiFpgaDll_UnreserveIrqContext", (NiFpga_FunctionPointer*)&NiFpga_unreserveIrqContext},
+   {"NiFpgaDll_WaitOnIrqs",          (NiFpga_FunctionPointer*)&NiFpga_waitOnIrqs},
+   {"NiFpgaDll_AcknowledgeIrqs",     (NiFpga_FunctionPointer*)&NiFpga_acknowledgeIrqs},
+   {"NiFpgaDll_ConfigureFifo",       (NiFpga_FunctionPointer*)&NiFpga_configureFifo},
+   {"NiFpgaDll_ConfigureFifo2",      (NiFpga_FunctionPointer*)&NiFpga_configureFifo2},
+   {"NiFpgaDll_StartFifo",           (NiFpga_FunctionPointer*)&NiFpga_startFifo},
+   {"NiFpgaDll_StopFifo",            (NiFpga_FunctionPointer*)&NiFpga_stopFifo},
+   {"NiFpgaDll_ReadFifoBool",        (NiFpga_FunctionPointer*)&NiFpga_readFifoBool},
+   {"NiFpgaDll_ReadFifoI8",          (NiFpga_FunctionPointer*)&NiFpga_readFifoI8},
+   {"NiFpgaDll_ReadFifoU8",          (NiFpga_FunctionPointer*)&NiFpga_readFifoU8},
+   {"NiFpgaDll_ReadFifoI16",         (NiFpga_FunctionPointer*)&NiFpga_readFifoI16},
+   {"NiFpgaDll_ReadFifoU16",         (NiFpga_FunctionPointer*)&NiFpga_readFifoU16},
+   {"NiFpgaDll_ReadFifoI32",         (NiFpga_FunctionPointer*)&NiFpga_readFifoI32},
+   {"NiFpgaDll_ReadFifoU32",         (NiFpga_FunctionPointer*)&NiFpga_readFifoU32},
+   {"NiFpgaDll_ReadFifoI64",         (NiFpga_FunctionPointer*)&NiFpga_readFifoI64},
+   {"NiFpgaDll_ReadFifoU64",         (NiFpga_FunctionPointer*)&NiFpga_readFifoU64},
+   {"NiFpgaDll_ReadFifoSgl",         (NiFpga_FunctionPointer*)&NiFpga_readFifoSgl},
+   {"NiFpgaDll_ReadFifoDbl",         (NiFpga_FunctionPointer*)&NiFpga_readFifoDbl},
+   {"NiFpgaDll_WriteFifoBool",       (NiFpga_FunctionPointer*)&NiFpga_writeFifoBool},
+   {"NiFpgaDll_WriteFifoI8",         (NiFpga_FunctionPointer*)&NiFpga_writeFifoI8},
+   {"NiFpgaDll_WriteFifoU8",         (NiFpga_FunctionPointer*)&NiFpga_writeFifoU8},
+   {"NiFpgaDll_WriteFifoI16",        (NiFpga_FunctionPointer*)&NiFpga_writeFifoI16},
+   {"NiFpgaDll_WriteFifoU16",        (NiFpga_FunctionPointer*)&NiFpga_writeFifoU16},
+   {"NiFpgaDll_WriteFifoI32",        (NiFpga_FunctionPointer*)&NiFpga_writeFifoI32},
+   {"NiFpgaDll_WriteFifoU32",        (NiFpga_FunctionPointer*)&NiFpga_writeFifoU32},
+   {"NiFpgaDll_WriteFifoI64",        (NiFpga_FunctionPointer*)&NiFpga_writeFifoI64},
+   {"NiFpgaDll_WriteFifoU64",        (NiFpga_FunctionPointer*)&NiFpga_writeFifoU64},
+   {"NiFpgaDll_WriteFifoSgl",        (NiFpga_FunctionPointer*)&NiFpga_writeFifoSgl},
+   {"NiFpgaDll_WriteFifoDbl",        (NiFpga_FunctionPointer*)&NiFpga_writeFifoDbl},
+   {"NiFpgaDll_AcquireFifoReadElementsBool",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsBool},
+   {"NiFpgaDll_AcquireFifoReadElementsI8",    (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsI8},
+   {"NiFpgaDll_AcquireFifoReadElementsU8",    (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsU8},
+   {"NiFpgaDll_AcquireFifoReadElementsI16",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsI16},
+   {"NiFpgaDll_AcquireFifoReadElementsU16",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsU16},
+   {"NiFpgaDll_AcquireFifoReadElementsI32",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsI32},
+   {"NiFpgaDll_AcquireFifoReadElementsU32",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsU32},
+   {"NiFpgaDll_AcquireFifoReadElementsI64",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsI64},
+   {"NiFpgaDll_AcquireFifoReadElementsU64",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsU64},
+   {"NiFpgaDll_AcquireFifoReadElementsSgl",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsSgl},
+   {"NiFpgaDll_AcquireFifoReadElementsDbl",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoReadElementsDbl},
+   {"NiFpgaDll_AcquireFifoWriteElementsBool", (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsBool},
+   {"NiFpgaDll_AcquireFifoWriteElementsI8",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsI8},
+   {"NiFpgaDll_AcquireFifoWriteElementsU8",   (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsU8},
+   {"NiFpgaDll_AcquireFifoWriteElementsI16",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsI16},
+   {"NiFpgaDll_AcquireFifoWriteElementsU16",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsU16},
+   {"NiFpgaDll_AcquireFifoWriteElementsI32",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsI32},
+   {"NiFpgaDll_AcquireFifoWriteElementsU32",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsU32},
+   {"NiFpgaDll_AcquireFifoWriteElementsI64",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsI64},
+   {"NiFpgaDll_AcquireFifoWriteElementsU64",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsU64},
+   {"NiFpgaDll_AcquireFifoWriteElementsSgl",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsSgl},
+   {"NiFpgaDll_AcquireFifoWriteElementsDbl",  (NiFpga_FunctionPointer*)&NiFpga_acquireFifoWriteElementsDbl},
+   {"NiFpgaDll_ReleaseFifoElements",          (NiFpga_FunctionPointer*)&NiFpga_releaseFifoElements},
+   {"NiFpgaDll_GetPeerToPeerFifoEndpoint",    (NiFpga_FunctionPointer*)&NiFpga_getPeerToPeerFifoEndpoint},
+   {"NiFpgaDll_GetBitfileContents",           (NiFpga_FunctionPointer*)&NiFpga_getBitfileContents},
+   {"NiFpgaDll_ClientFunctionCall",           (NiFpga_FunctionPointer*)&NiFpga_clientFunctionCall},
+   {NULL, NULL}
+};
+
+NiFpga_Status NiFpga_Initialize(void)
+{
+   /* if the library isn't already loaded */
+   if (!NiFpga_library)
+   {
+      int i;
+      /* load the library */
+      #if NiFpga_Windows
+         NiFpga_library = LoadLibraryA("NiFpga.dll");
+      #elif NiFpga_VxWorks
+         NiFpga_library = VxLoadLibraryFromPath("NiFpga.out", 0);
+      #elif NiFpga_Linux || NiFpga_MacOsX
+         #if NiFpga_Linux
+            const char* const library = "libNiFpga.so";
+         #elif NiFpga_MacOsX
+            const char* const library =
+               "/Library/Frameworks/NiFpga.framework/NiFpga";
+         #endif
+         NiFpga_library = dlopen(library, RTLD_LAZY);
+         if (!NiFpga_library)
+            fprintf(stderr, "Error opening %s: %s\n", library, dlerror());
+      #else
+         #error
+      #endif
+      if (!NiFpga_library)
+         return NiFpga_Status_ResourceNotFound;
+      /* get each exported function */
+      for (i = 0; NiFpga_functions[i].name; i++)
+      {
+         const char* const name = NiFpga_functions[i].name;
+         NiFpga_FunctionPointer* const address = NiFpga_functions[i].address;
+         #if NiFpga_Windows
+            *address = (NiFpga_FunctionPointer)GetProcAddress(NiFpga_library,
+                                                              name);
+            if (!*address)
+               return NiFpga_Status_VersionMismatch;
+         #elif NiFpga_VxWorks
+            SYM_TYPE type;
+            if (symFindByName(sysSymTbl,
+                              (char*)name,
+                              (char**)address,
+                              &type) != OK)
+               return NiFpga_Status_VersionMismatch;
+         #elif NiFpga_Linux || NiFpga_MacOsX
+            *address = (NiFpga_FunctionPointer)dlsym(NiFpga_library, name);
+            if (!*address)
+               return NiFpga_Status_VersionMismatch;
+         #else
+            #error
+         #endif
+      }
+      /* enable CVI Resource Tracking, if available */
+      #if NiFpga_CviResourceTracking
+      {
+         HMODULE engine = GetModuleHandle("cvirte.dll");
+         if (!engine)
+            engine = GetModuleHandle("cvi_lvrt.dll");
+         if (!engine)
+            engine = GetModuleHandle("instrsup.dll");
+         if (engine)
+         {
+            NiFpga_acquireCviResource =
+               (NiFpga_AcquireCviResource)
+                  GetProcAddress(engine, "__CVI_Resource_Acquire");
+            NiFpga_releaseCviResource =
+               (NiFpga_ReleaseCviResource)
+                  GetProcAddress(engine, "__CVI_Resource_Release");
+            if (!NiFpga_acquireCviResource
+            ||  !NiFpga_releaseCviResource)
+            {
+               NiFpga_acquireCviResource = NULL;
+               NiFpga_releaseCviResource = NULL;
+            }
+         }
+      }
+      #endif
+   }
+   return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_Finalize(void)
+{
+   /* if the library is currently loaded */
+   if (NiFpga_library)
+   {
+      int i;
+      NiFpga_Status status = NiFpga_Status_Success;
+      /* unload the library */
+      #if NiFpga_Windows
+         if (!FreeLibrary(NiFpga_library))
+            status = NiFpga_Status_ResourceNotInitialized;
+      #elif NiFpga_VxWorks
+         if (VxFreeLibrary(NiFpga_library, 0) != OK)
+            status = NiFpga_Status_ResourceNotInitialized;
+      #elif NiFpga_Linux || NiFpga_MacOsX
+         if (dlclose(NiFpga_library))
+            status = NiFpga_Status_ResourceNotInitialized;
+      #else
+         #error
+      #endif
+      /* null out the library and each exported function */
+      NiFpga_library = NULL;
+      for (i = 0; NiFpga_functions[i].name; i++)
+         *NiFpga_functions[i].address = NULL;
+      /* null out the CVI Resource Tracking functions */
+      #if NiFpga_CviResourceTracking
+         NiFpga_acquireCviResource = NULL;
+         NiFpga_releaseCviResource = NULL;
+      #endif
+      return status;
+   }
+   else
+      return NiFpga_Status_ResourceNotInitialized;
+}

--- a/nifpga_shim/NiFpga.h
+++ b/nifpga_shim/NiFpga.h
@@ -1,0 +1,2807 @@
+/*
+ * FPGA Interface C API 17.0 header file.
+ *
+ * Copyright (c) 2017,
+ * National Instruments Corporation.
+ * All rights reserved.
+ */
+
+#ifndef __NiFpga_h__
+#define __NiFpga_h__
+
+/*
+ * Determine platform details.
+ */
+#if defined(_M_IX86) \
+ || defined(_M_X64) \
+ || defined(_M_AMD64) \
+ || defined(i386) \
+ || defined(__i386) \
+ || defined(__i386__) \
+ || defined(__i486__) \
+ || defined(__i586__) \
+ || defined(__i686__) \
+ || defined(__amd64__) \
+ || defined(__amd64) \
+ || defined(__x86_64__) \
+ || defined(__x86_64) \
+ || defined(__IA32__) \
+ || defined(_X86_) \
+ || defined(__THW_INTEL__) \
+ || defined(__I86__) \
+ || defined(__INTEL__) \
+ || defined(__X86__) \
+ || defined(__386__) \
+ || defined(__I86__) \
+ || defined(M_I386) \
+ || defined(M_I86) \
+ || defined(_M_I386) \
+ || defined(_M_I86)
+   #if defined(_WIN32) \
+    || defined(_WIN64) \
+    || defined(__WIN32__) \
+    || defined(__TOS_WIN__) \
+    || defined(__WINDOWS__) \
+    || defined(_WINDOWS) \
+    || defined(__WINDOWS_386__) \
+    || defined(__CYGWIN__)
+      /* Either Windows or Phar Lap ETS. */
+      #define NiFpga_Windows 1
+   #elif defined(__linux__) \
+      || defined(__linux) \
+      || defined(linux) \
+      || defined(__gnu_linux__)
+      #define NiFpga_Linux 1
+   #elif defined(__APPLE__) && defined(__MACH__)
+      #define NiFpga_MacOsX 1
+   #else
+      #error Unsupported OS.
+   #endif
+#elif defined(__powerpc) \
+   || defined(__powerpc__) \
+   || defined(__POWERPC__) \
+   || defined(__ppc__) \
+   || defined(__PPC) \
+   || defined(_M_PPC) \
+   || defined(_ARCH_PPC) \
+   || defined(__PPC__) \
+   || defined(__ppc)
+   #if defined(__vxworks)
+      #define NiFpga_VxWorks 1
+   #else
+      #error Unsupported OS.
+   #endif
+#elif defined(__arm__) \
+   || defined(__thumb__) \
+   || defined(__TARGET_ARCH_ARM) \
+   || defined(__TARGET_ARCH_THUMB) \
+   || defined(_ARM) \
+   || defined(_M_ARM) \
+   || defined(_M_ARMT)
+#if defined(__linux__) \
+ || defined(__linux) \
+ || defined(linux) \
+ || defined(__gnu_linux__)
+   #define NiFpga_Linux 1
+#else
+      #error Unsupported OS.
+   #endif
+#else
+   #error Unsupported architecture.
+#endif
+
+/*
+ * Determine compiler.
+ */
+#if defined(_MSC_VER)
+   #define NiFpga_Msvc 1
+#elif defined(__GNUC__)
+   #define NiFpga_Gcc 1
+#elif defined(_CVI_) && !defined(_TPC_)
+   #define NiFpga_Cvi 1
+   /* Enables CVI Library Protection Errors. */
+   #pragma EnableLibraryRuntimeChecking
+#else
+   /* Unknown compiler. */
+#endif
+
+/*
+ * Determine compliance with different C/C++ language standards.
+ */
+#if defined(__cplusplus)
+   #define NiFpga_Cpp 1
+   #if __cplusplus >= 199707L
+      #define NiFpga_Cpp98 1
+      #if __cplusplus >= 201103L
+         #define NiFpga_Cpp11 1
+      #endif
+   #endif
+#endif
+#if defined(__STDC__)
+   #define NiFpga_C89 1
+   #if defined(__STDC_VERSION__)
+      #define NiFpga_C90 1
+      #if __STDC_VERSION__ >= 199409L
+         #define NiFpga_C94 1
+         #if __STDC_VERSION__ >= 199901L
+            #define NiFpga_C99 1
+            #if __STDC_VERSION__ >= 201112L
+               #define NiFpga_C11 1
+            #endif
+         #endif
+      #endif
+   #endif
+#endif
+
+/*
+ * Determine ability to inline functions.
+ */
+#if NiFpga_Cpp || NiFpga_C99
+   /* The inline keyword exists in C++ and C99. */
+   #define NiFpga_Inline inline
+#elif NiFpga_Msvc
+   /* Visual C++ (at least since 6.0) also supports an alternate keyword. */
+   #define NiFpga_Inline __inline
+#elif NiFpga_Gcc
+   /* GCC (at least since 2.95.2) also supports an alternate keyword. */
+   #define NiFpga_Inline __inline__
+#elif !defined(NiFpga_Inline)
+   /*
+    * Disable inlining if inline support is unknown. To manually enable
+    * inlining, #define the following macro before #including NiFpga.h:
+    *
+    *    #define NiFpga_Inline inline
+    */
+   #define NiFpga_Inline
+#endif
+
+/*
+ * Define exact-width integer types, if they have not already been defined.
+ */
+#if NiFpga_ExactWidthIntegerTypesDefined \
+ || defined(_STDINT) \
+ || defined(_STDINT_H) \
+ || defined(_STDINT_H_) \
+ || defined(_INTTYPES_H) \
+ || defined(_INTTYPES_H_) \
+ || defined(_SYS_STDINT_H) \
+ || defined(_SYS_STDINT_H_) \
+ || defined(_SYS_INTTYPES_H) \
+ || defined(_SYS_INTTYPES_H_) \
+ || defined(_STDINT_H_INCLUDED) \
+ || defined(_MSC_STDINT_H_) \
+ || defined(_PSTDINT_H_INCLUDED)
+   /* Assume that exact-width integer types have already been defined. */
+#elif NiFpga_VxWorks
+   /* VxWorks (at least 6.3 and earlier) did not have stdint.h. */
+   #include <types/vxTypes.h>
+#elif NiFpga_C99 \
+   || NiFpga_Gcc /* GCC (at least since 3.0) has a stdint.h. */ \
+   || defined(HAVE_STDINT_H)
+   /* Assume that stdint.h can be included. */
+   #include <stdint.h>
+#elif NiFpga_Msvc \
+   || NiFpga_Cvi
+   /* Manually define exact-width integer types. */
+   typedef   signed    char  int8_t;
+   typedef unsigned    char uint8_t;
+   typedef            short  int16_t;
+   typedef unsigned   short uint16_t;
+   typedef          __int32  int32_t;
+   typedef unsigned __int32 uint32_t;
+   typedef          __int64  int64_t;
+   typedef unsigned __int64 uint64_t;
+#else
+   /*
+    * Exact-width integer types must be defined by the user, and the following
+    * macro must be #defined, before #including NiFpga.h:
+    *
+    *    #define NiFpga_ExactWidthIntegerTypesDefined 1
+    */
+   #error Exact-width integer types must be defined by the user. See comment.
+#endif
+
+/* Included for definition of size_t. */
+#include <stddef.h>
+
+#if NiFpga_Cpp
+extern "C"
+{
+#endif
+
+/**
+ * A boolean value; either NiFpga_False or NiFpga_True.
+ */
+typedef uint8_t NiFpga_Bool;
+
+/**
+ * Represents a false condition.
+ */
+static const NiFpga_Bool NiFpga_False = 0;
+
+/**
+ * Represents a true condition.
+ */
+static const NiFpga_Bool NiFpga_True = 1;
+
+/**
+ * Represents the resulting status of a function call through its return value.
+ * 0 is success, negative values are errorint_ts, and positive values are warnings.
+ */
+typedef int32_t NiFpga_Status;
+
+/**
+ * No errors or warnings.
+ */
+static const NiFpga_Status NiFpga_Status_Success = 0;
+
+/**
+ * The timeout expired before the FIFO operation could complete.
+ */
+static const NiFpga_Status NiFpga_Status_FifoTimeout = -50400;
+
+/**
+ * No transfer is in progress because the transfer was aborted by the client.
+ * The operation could not be completed as specified.
+ */
+static const NiFpga_Status NiFpga_Status_TransferAborted = -50405;
+
+/**
+ * A memory allocation failed. Try again after rebooting.
+ */
+static const NiFpga_Status NiFpga_Status_MemoryFull = -52000;
+
+/**
+ * An unexpected software error occurred.
+ */
+static const NiFpga_Status NiFpga_Status_SoftwareFault = -52003;
+
+/**
+ * A parameter to a function was not valid. This could be a NULL pointer, a bad
+ * value, etc.
+ */
+static const NiFpga_Status NiFpga_Status_InvalidParameter = -52005;
+
+/**
+ * A required resource was not found. The NiFpga.* library, the RIO resource, or
+ * some other resource may be missing.
+ */
+static const NiFpga_Status NiFpga_Status_ResourceNotFound = -52006;
+
+/**
+ * A required resource was not properly initialized. This could occur if
+ * NiFpga_Initialize was not called or a required NiFpga_IrqContext was not
+ * reserved.
+ */
+static const NiFpga_Status NiFpga_Status_ResourceNotInitialized = -52010;
+
+/**
+ * The FPGA is already running.
+ */
+static const NiFpga_Status NiFpga_Status_FpgaAlreadyRunning = -61003;
+
+/**
+ * An error occurred downloading the VI to the FPGA device. Verify that
+ * the target is connected and powered and that the resource of the target
+ * is properly configured.
+ */
+static const NiFpga_Status NiFpga_Status_DownloadError = -61018;
+
+/**
+ * The bitfile was not compiled for the specified resource's device type.
+ */
+static const NiFpga_Status NiFpga_Status_DeviceTypeMismatch = -61024;
+
+/**
+ * An error was detected in the communication between the host computer and the
+ * FPGA target.
+ */
+static const NiFpga_Status NiFpga_Status_CommunicationTimeout = -61046;
+
+/**
+ * The timeout expired before any of the IRQs were asserted.
+ */
+static const NiFpga_Status NiFpga_Status_IrqTimeout = -61060;
+
+/**
+ * The specified bitfile is invalid or corrupt.
+ */
+static const NiFpga_Status NiFpga_Status_CorruptBitfile = -61070;
+
+/**
+ * The requested FIFO depth is invalid. It is either 0 or an amount not
+ * supported by the hardware.
+ */
+static const NiFpga_Status NiFpga_Status_BadDepth = -61072;
+
+/**
+ * The number of FIFO elements is invalid. Either the number is greater than the
+ * depth of the host memory DMA FIFO, or more elements were requested for
+ * release than had been acquired.
+ */
+static const NiFpga_Status NiFpga_Status_BadReadWriteCount = -61073;
+
+/**
+ * A hardware clocking error occurred. A derived clock lost lock with its base
+ * clock during the execution of the LabVIEW FPGA VI. If any base clocks with
+ * derived clocks are referencing an external source, make sure that the
+ * external source is connected and within the supported frequency, jitter,
+ * accuracy, duty cycle, and voltage specifications. Also verify that the
+ * characteristics of the base clock match the configuration specified in the
+ * FPGA Base Clock Properties. If all base clocks with derived clocks are
+ * generated from free-running, on-board sources, please contact National
+ * Instruments technical support at ni.com/support.
+ */
+static const NiFpga_Status NiFpga_Status_ClockLostLock = -61083;
+
+/**
+ * The operation could not be performed because the FPGA is busy. Stop all
+ * activities on the FPGA before requesting this operation. If the target is in
+ * Scan Interface programming mode, put it in FPGA Interface programming mode.
+ */
+static const NiFpga_Status NiFpga_Status_FpgaBusy = -61141;
+
+/**
+ * The operation could not be performed because the FPGA is busy operating in
+ * FPGA Interface C API mode. Stop all activities on the FPGA before requesting
+ * this operation.
+ */
+static const NiFpga_Status NiFpga_Status_FpgaBusyFpgaInterfaceCApi = -61200;
+
+/**
+ * The chassis is in Scan Interface programming mode. In order to run FPGA VIs,
+ * you must go to the chassis properties page, select FPGA programming mode, and
+ * deploy settings.
+ */
+static const NiFpga_Status NiFpga_Status_FpgaBusyScanInterface = -61201;
+
+/**
+ * The operation could not be performed because the FPGA is busy operating in
+ * FPGA Interface mode. Stop all activities on the FPGA before requesting this
+ * operation.
+ */
+static const NiFpga_Status NiFpga_Status_FpgaBusyFpgaInterface = -61202;
+
+/**
+ * The operation could not be performed because the FPGA is busy operating in
+ * Interactive mode. Stop all activities on the FPGA before requesting this
+ * operation.
+ */
+static const NiFpga_Status NiFpga_Status_FpgaBusyInteractive = -61203;
+
+/**
+ * The operation could not be performed because the FPGA is busy operating in
+ * Emulation mode. Stop all activities on the FPGA before requesting this
+ * operation.
+ */
+static const NiFpga_Status NiFpga_Status_FpgaBusyEmulation = -61204;
+
+/**
+ * LabVIEW FPGA does not support the Reset method for bitfiles that allow
+ * removal of implicit enable signals in single-cycle Timed Loops.
+ */
+static const NiFpga_Status NiFpga_Status_ResetCalledWithImplicitEnableRemoval = -61211;
+
+/**
+ * LabVIEW FPGA does not support the Abort method for bitfiles that allow
+ * removal of implicit enable signals in single-cycle Timed Loops.
+ */
+static const NiFpga_Status NiFpga_Status_AbortCalledWithImplicitEnableRemoval = -61212;
+
+/**
+ * LabVIEW FPGA does not support Close and Reset if Last Reference for bitfiles
+ * that allow removal of implicit enable signals in single-cycle Timed Loops.
+ * Pass the NiFpga_CloseAttribute_NoResetIfLastSession attribute to NiFpga_Close
+ * instead of 0.
+ */
+static const NiFpga_Status NiFpga_Status_CloseAndResetCalledWithImplicitEnableRemoval = -61213;
+
+/**
+ * For bitfiles that allow removal of implicit enable signals in single-cycle
+ * Timed Loops, LabVIEW FPGA does not support this method prior to running the
+ * bitfile.
+ */
+static const NiFpga_Status NiFpga_Status_ImplicitEnableRemovalButNotYetRun = -61214;
+
+/**
+ * Bitfiles that allow removal of implicit enable signals in single-cycle Timed
+ * Loops can run only once. Download the bitfile again before re-running the VI.
+ */
+static const NiFpga_Status NiFpga_Status_RunAfterStoppedCalledWithImplicitEnableRemoval = -61215;
+
+/**
+ * A gated clock has violated the handshaking protocol. If you are using
+ * external gated clocks, ensure that they follow the required clock gating
+ * protocol. If you are generating your clocks internally, please contact
+ * National Instruments Technical Support.
+ */
+static const NiFpga_Status NiFpga_Status_GatedClockHandshakingViolation = -61216;
+
+/**
+ * The number of elements requested must be less than or equal to the number of
+ * unacquired elements left in the host memory DMA FIFO. There are currently
+ * fewer unacquired elements left in the FIFO than are being requested. Release
+ * some acquired elements before acquiring more elements.
+ */
+static const NiFpga_Status NiFpga_Status_ElementsNotPermissibleToBeAcquired = -61219;
+
+/**
+ * The operation could not be performed because the FPGA is in configuration or
+ * discovery mode. Wait for configuration or discovery to complete and retry
+ * your operation.
+ */
+static const NiFpga_Status NiFpga_Status_FpgaBusyConfiguration = -61252;
+
+/**
+ * LabVIEW FPGA does not support Close and Reset if Last Reference for bitfiles
+ * that do not support Reset. Pass the
+ * NiFpga_CloseAttribute_NoResetIfLastSession attribute to NiFpga_Close instead
+ * of 0.
+ */
+static const NiFpga_Status NiFpga_Status_CloseAndResetCalledWithResetNotSupported = -61253;
+
+/**
+ * An unexpected internal error occurred.
+ */
+static const NiFpga_Status NiFpga_Status_InternalError = -61499;
+
+/**
+ * The NI-RIO driver was unable to allocate memory for a FIFO. This can happen
+ * when the combined depth of all DMA FIFOs exceeds the maximum depth for the
+ * controller, or when the controller runs out of system memory. You may be able
+ * to reconfigure the controller with a greater maximum FIFO depth. For more
+ * information, refer to the NI KnowledgeBase article 65OF2ERQ.
+ */
+static const NiFpga_Status NiFpga_Status_TotalDmaFifoDepthExceeded = -63003;
+
+/**
+ * Access to the remote system was denied. Use MAX to check the Remote Device
+ * Access settings under Software>>NI-RIO>>NI-RIO Settings on the remote system.
+ */
+static const NiFpga_Status NiFpga_Status_AccessDenied = -63033;
+
+/**
+ * The NI-RIO software on the host is not compatible with the software on the
+ * target. Upgrade the NI-RIO software on the host in order to connect to this
+ * target.
+ */
+static const NiFpga_Status NiFpga_Status_HostVersionMismatch = -63038;
+
+/**
+ * A connection could not be established to the specified remote device. Ensure
+ * that the device is on and accessible over the network, that NI-RIO software
+ * is installed, and that the RIO server is running and properly configured.
+ */
+static const NiFpga_Status NiFpga_Status_RpcConnectionError = -63040;
+
+/**
+ * The RPC session is invalid. The target may have reset or been rebooted. Check
+ * the network connection and retry the operation.
+ */
+static const NiFpga_Status NiFpga_Status_RpcSessionError = -63043;
+
+/**
+ * The operation could not complete because another session is accessing the
+ * FIFO. Close the other session and retry.
+ */
+static const NiFpga_Status NiFpga_Status_FifoReserved = -63082;
+
+/**
+ * A Configure FIFO, Stop FIFO, Read FIFO, or Write FIFO function was called
+ * while the host had acquired elements of the FIFO. Release all acquired
+ * elements before configuring, stopping, reading, or writing.
+ */
+static const NiFpga_Status NiFpga_Status_FifoElementsCurrentlyAcquired = -63083;
+
+/**
+ * A function was called using a misaligned address. The address must be a
+ * multiple of the size of the datatype.
+ */
+static const NiFpga_Status NiFpga_Status_MisalignedAccess = -63084;
+
+/**
+ * The FPGA Read/Write Control Function is accessing a control or indicator
+ * with data that exceeds the maximum size supported on the current target.
+ * Refer to the hardware documentation for the limitations on data types for
+ * this target.
+ */
+static const NiFpga_Status NiFpga_Status_ControlOrIndicatorTooLarge = -63085;
+
+/**
+ * A valid .lvbitx bitfile is required. If you are using a valid .lvbitx
+ * bitfile, the bitfile may not be compatible with the software you are using.
+ * Determine which version of LabVIEW was used to make the bitfile, update your
+ * software to that version or later, and try again.
+ */
+static const NiFpga_Status NiFpga_Status_BitfileReadError = -63101;
+
+/**
+ * The specified signature does not match the signature of the bitfile. If the
+ * bitfile has been recompiled, regenerate the C API and rebuild the
+ * application.
+ */
+static const NiFpga_Status NiFpga_Status_SignatureMismatch = -63106;
+
+/**
+ * The bitfile you are trying to use is incompatible with the version
+ * of NI-RIO installed on the target and/or host. Update the version
+ * of NI-RIO on the target and/or host to the same version (or later)
+ * used to compile the bitfile. Alternatively, recompile the bitfile
+ * with the same version of NI-RIO that is currently installed on the
+ * target and/or host.
+ */
+static const NiFpga_Status NiFpga_Status_IncompatibleBitfile = -63107;
+
+/**
+ * A hardware failure has occurred. The operation could not be completed as
+ * specified.
+ */
+static const NiFpga_Status NiFpga_Status_HardwareFault = -63150;
+
+/**
+ * Either the supplied resource name is invalid as a RIO resource name, or the
+ * device was not found. Use MAX to find the proper resource name for the
+ * intended device.
+ */
+static const NiFpga_Status NiFpga_Status_InvalidResourceName = -63192;
+
+/**
+ * The requested feature is not supported.
+ */
+static const NiFpga_Status NiFpga_Status_FeatureNotSupported = -63193;
+
+/**
+ * The NI-RIO software on the target system is not compatible with this
+ * software. Upgrade the NI-RIO software on the target system.
+ */
+static const NiFpga_Status NiFpga_Status_VersionMismatch = -63194;
+
+/**
+ * The session is invalid or has been closed.
+ */
+static const NiFpga_Status NiFpga_Status_InvalidSession = -63195;
+
+/**
+ * The maximum number of open FPGA sessions has been reached. Close some open
+ * sessions.
+ */
+static const NiFpga_Status NiFpga_Status_OutOfHandles = -63198;
+
+/**
+ * Tests whether a status is an error.
+ *
+ * @param status status to check for an error
+ * @return whether the status was an error
+ */
+static NiFpga_Inline NiFpga_Bool NiFpga_IsError(const NiFpga_Status status)
+{
+   return status < NiFpga_Status_Success ? NiFpga_True : NiFpga_False;
+}
+
+/**
+ * Tests whether a status is not an error. Success and warnings are not errors.
+ *
+ * @param status status to check for an error
+ * @return whether the status was a success or warning
+ */
+static NiFpga_Inline NiFpga_Bool NiFpga_IsNotError(const NiFpga_Status status)
+{
+   return status >= NiFpga_Status_Success ? NiFpga_True : NiFpga_False;
+}
+
+/**
+ * Conditionally sets the status to a new value. The previous status is
+ * preserved unless the new status is more of an error, which means that
+ * warnings and errors overwrite successes, and errors overwrite warnings. New
+ * errors do not overwrite older errors, and new warnings do not overwrite
+ * older warnings.
+ *
+ * @param status status to conditionally set
+ * @param newStatus new status value that may be set
+ * @return the resulting status
+ */
+static NiFpga_Inline NiFpga_Status NiFpga_MergeStatus(
+                                               NiFpga_Status* const status,
+                                               const NiFpga_Status  newStatus)
+{
+   if (!status)
+      return NiFpga_Status_InvalidParameter;
+   if (NiFpga_IsNotError(*status)
+   &&  (*status == NiFpga_Status_Success || NiFpga_IsError(newStatus)))
+      *status = newStatus;
+   return *status;
+}
+
+/**
+ * This macro evaluates the expression only if the status is not an error. The
+ * expression must evaluate to an NiFpga_Status, such as a call to any NiFpga_*
+ * function, because the status will be set to the returned status if the
+ * expression is evaluated.
+ *
+ * You can use this macro to mimic status chaining in LabVIEW, where the status
+ * does not have to be explicitly checked after each call. Such code may look
+ * like the following example.
+ *
+ *    NiFpga_Status status = NiFpga_Status_Success;
+ *    NiFpga_IfIsNotError(status, NiFpga_WriteU32(...));
+ *    NiFpga_IfIsNotError(status, NiFpga_WriteU32(...));
+ *    NiFpga_IfIsNotError(status, NiFpga_WriteU32(...));
+ *
+ * @param status status to check for an error
+ * @param expression expression to call if the incoming status is not an error
+ */
+#define NiFpga_IfIsNotError(status, expression) \
+   if (NiFpga_IsNotError(status)) \
+      NiFpga_MergeStatus(&status, (expression)); \
+
+/**
+ * You must call this function before all other function calls. This function
+ * loads the NiFpga library so that all the other functions will work. If this
+ * function succeeds, you must call NiFpga_Finalize after all other function
+ * calls.
+ *
+ * @warning This function is not thread safe.
+ *
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_Initialize(void);
+
+/**
+ * You must call this function after all other function calls if
+ * NiFpga_Initialize succeeds. This function unloads the NiFpga library.
+ *
+ * @warning This function is not thread safe.
+ *
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_Finalize(void);
+
+/**
+ * A handle to an FPGA session.
+ */
+typedef uint32_t NiFpga_Session;
+
+/**
+ * Attributes that NiFpga_Open accepts.
+ */
+typedef enum
+{
+   NiFpga_OpenAttribute_NoRun = 1
+} NiFpga_OpenAttribute;
+
+/**
+ * Opens a session to the FPGA. This call ensures that the contents of the
+ * bitfile are programmed to the FPGA. The FPGA runs unless the
+ * NiFpga_OpenAttribute_NoRun attribute is used.
+ *
+ * Because different operating systems have different default current working
+ * directories for applications, you must pass an absolute path for the bitfile
+ * parameter. If you pass only the filename instead of an absolute path, the
+ * operating system may not be able to locate the bitfile. For example, the
+ * default current working directories are C:\ni-rt\system\ for Phar Lap ETS and
+ * /c/ for VxWorks. Because the generated *_Bitfile constant is a #define to a
+ * string literal, you can use C/C++ string-literal concatenation to form an
+ * absolute path. For example, if the bitfile is in the root directory of a
+ * Phar Lap ETS system, pass the following for the bitfile parameter.
+ *
+ *    "C:\\" NiFpga_MyApplication_Bitfile
+ *
+ * @param bitfile path to the bitfile
+ * @param signature signature of the bitfile
+ * @param resource RIO resource string to open ("RIO0" or "rio://mysystem/RIO")
+ * @param attribute bitwise OR of any NiFpga_OpenAttributes, or 0
+ * @param session outputs the session handle, which must be closed when no
+ *                longer needed
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_Open(const char*     bitfile,
+                          const char*     signature,
+                          const char*     resource,
+                          uint32_t        attribute,
+                          NiFpga_Session* session);
+
+/**
+ * Attributes that NiFpga_Close accepts.
+ */
+typedef enum
+{
+   NiFpga_CloseAttribute_NoResetIfLastSession = 1
+} NiFpga_CloseAttribute;
+
+/**
+ * Closes the session to the FPGA. The FPGA resets unless either another session
+ * is still open or you use the NiFpga_CloseAttribute_NoResetIfLastSession
+ * attribute.
+ *
+ * @param session handle to a currently open session
+ * @param attribute bitwise OR of any NiFpga_CloseAttributes, or 0
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_Close(NiFpga_Session session,
+                           uint32_t       attribute);
+
+/**
+ * Attributes that NiFpga_Run accepts.
+ */
+typedef enum
+{
+   NiFpga_RunAttribute_WaitUntilDone = 1
+} NiFpga_RunAttribute;
+
+/**
+ * Runs the FPGA VI on the target. If you use NiFpga_RunAttribute_WaitUntilDone,
+ * NiFpga_Run blocks the thread until the FPGA finishes running.
+ *
+ * @param session handle to a currently open session
+ * @param attribute bitwise OR of any NiFpga_RunAttributes, or 0
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_Run(NiFpga_Session session,
+                         uint32_t       attribute);
+
+/**
+ * Aborts the FPGA VI.
+ *
+ * @param session handle to a currently open session
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_Abort(NiFpga_Session session);
+
+/**
+ * Resets the FPGA VI.
+ *
+ * @param session handle to a currently open session
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_Reset(NiFpga_Session session);
+
+/**
+ * Re-downloads the FPGA bitstream to the target.
+ *
+ * @param session handle to a currently open session
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_Download(NiFpga_Session session);
+
+/**
+ * Reads a boolean value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadBool(NiFpga_Session session,
+                              uint32_t       indicator,
+                              NiFpga_Bool*   value);
+
+/**
+ * Reads a signed 8-bit integer value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadI8(NiFpga_Session session,
+                            uint32_t       indicator,
+                            int8_t*        value);
+
+/**
+ * Reads an unsigned 8-bit integer value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadU8(NiFpga_Session session,
+                            uint32_t       indicator,
+                            uint8_t*       value);
+
+/**
+ * Reads a signed 16-bit integer value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadI16(NiFpga_Session session,
+                             uint32_t       indicator,
+                             int16_t*       value);
+
+/**
+ * Reads an unsigned 16-bit integer value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadU16(NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint16_t*      value);
+
+/**
+ * Reads a signed 32-bit integer value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadI32(NiFpga_Session session,
+                             uint32_t       indicator,
+                             int32_t*       value);
+
+/**
+ * Reads an unsigned 32-bit integer value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadU32(NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint32_t*      value);
+
+/**
+ * Reads a signed 64-bit integer value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadI64(NiFpga_Session session,
+                             uint32_t       indicator,
+                             int64_t*       value);
+
+/**
+ * Reads an unsigned 64-bit integer value from a given indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadU64(NiFpga_Session session,
+                             uint32_t       indicator,
+                             uint64_t*      value);
+
+/**
+ * Reads a single-precision floating-point value from a given indicator or
+ * control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadSgl(NiFpga_Session session,
+                             uint32_t       indicator,
+                             float*         value);
+
+/**
+ * Reads a double-precision floating-point value from a given indicator or
+ * control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param value outputs the value that was read
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadDbl(NiFpga_Session session,
+                             uint32_t       indicator,
+                             double*        value);
+
+/**
+ * Writes a boolean value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteBool(NiFpga_Session session,
+                               uint32_t       control,
+                               NiFpga_Bool    value);
+
+/**
+ * Writes a signed 8-bit integer value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteI8(NiFpga_Session session,
+                             uint32_t       control,
+                             int8_t         value);
+
+/**
+ * Writes an unsigned 8-bit integer value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteU8(NiFpga_Session session,
+                             uint32_t       control,
+                             uint8_t        value);
+
+/**
+ * Writes a signed 16-bit integer value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteI16(NiFpga_Session session,
+                              uint32_t       control,
+                              int16_t        value);
+
+/**
+ * Writes an unsigned 16-bit integer value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteU16(NiFpga_Session session,
+                              uint32_t       control,
+                              uint16_t       value);
+
+/**
+ * Writes a signed 32-bit integer value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteI32(NiFpga_Session session,
+                              uint32_t       control,
+                              int32_t        value);
+
+/**
+ * Writes an unsigned 32-bit integer value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteU32(NiFpga_Session session,
+                              uint32_t       control,
+                              uint32_t       value);
+
+/**
+ * Writes a signed 64-bit integer value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteI64(NiFpga_Session session,
+                              uint32_t       control,
+                              int64_t        value);
+
+/**
+ * Writes an unsigned 64-bit integer value to a given control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteU64(NiFpga_Session session,
+                              uint32_t       control,
+                              uint64_t       value);
+
+/**
+ * Writes a single-precision floating-point value to a given control or
+ * indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteSgl(NiFpga_Session session,
+                              uint32_t       control,
+                              float          value);
+
+/**
+ * Writes a double-precision floating-point value to a given control or
+ * indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param value value to write
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteDbl(NiFpga_Session session,
+                              uint32_t       control,
+                              double         value);
+
+/**
+ * Reads an entire array of boolean values from a given array indicator or
+ * control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayBool(NiFpga_Session session,
+                                   uint32_t       indicator,
+                                   NiFpga_Bool*   array,
+                                   size_t         size);
+
+/**
+ * Reads an entire array of signed 8-bit integer values from a given array
+ * indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayI8(NiFpga_Session session,
+                                 uint32_t       indicator,
+                                 int8_t*        array,
+                                 size_t         size);
+
+/**
+ * Reads an entire array of unsigned 8-bit integer values from a given array
+ * indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayU8(NiFpga_Session session,
+                                 uint32_t       indicator,
+                                 uint8_t*       array,
+                                 size_t         size);
+
+/**
+ * Reads an entire array of signed 16-bit integer values from a given array
+ * indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayI16(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int16_t*       array,
+                                  size_t         size);
+
+/**
+ * Reads an entire array of unsigned 16-bit integer values from a given array
+ * indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayU16(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint16_t*      array,
+                                  size_t         size);
+
+/**
+ * Reads an entire array of signed 32-bit integer values from a given array
+ * indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayI32(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int32_t*       array,
+                                  size_t         size);
+
+/**
+ * Reads an entire array of unsigned 32-bit integer values from a given array
+ * indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayU32(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint32_t*      array,
+                                  size_t         size);
+
+/**
+ * Reads an entire array of signed 64-bit integer values from a given array
+ * indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayI64(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  int64_t*       array,
+                                  size_t         size);
+
+/**
+ * Reads an entire array of unsigned 64-bit integer values from a given array
+ * indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayU64(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  uint64_t*      array,
+                                  size_t         size);
+
+/**
+ * Reads an entire array of single-precision floating-point values from a
+ * given array indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArraySgl(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  float*         array,
+                                  size_t         size);
+
+/**
+ * Reads an entire array of double-precision floating-point values from a
+ * given array indicator or control.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          indicator or control.
+ *
+ * @param session handle to a currently open session
+ * @param indicator indicator or control from which to read
+ * @param array outputs the entire array that was read
+ * @param size exact number of elements in the indicator or control
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadArrayDbl(NiFpga_Session session,
+                                  uint32_t       indicator,
+                                  double*        array,
+                                  size_t         size);
+
+/**
+ * Writes an entire array of boolean values to a given array control or
+ * indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayBool(NiFpga_Session     session,
+                                    uint32_t           control,
+                                    const NiFpga_Bool* array,
+                                    size_t             size);
+
+/**
+ * Writes an entire array of signed 8-bit integer values to a given array
+ * control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayI8(NiFpga_Session session,
+                                  uint32_t       control,
+                                  const int8_t*  array,
+                                  size_t         size);
+
+/**
+ * Writes an entire array of unsigned 8-bit integer values to a given array
+ * control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayU8(NiFpga_Session session,
+                                  uint32_t       control,
+                                  const uint8_t* array,
+                                  size_t         size);
+
+/**
+ * Writes an entire array of signed 16-bit integer values to a given array
+ * control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayI16(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int16_t* array,
+                                   size_t         size);
+
+/**
+ * Writes an entire array of unsigned 16-bit integer values to a given array
+ * control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayU16(NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint16_t* array,
+                                   size_t          size);
+
+/**
+ * Writes an entire array of signed 32-bit integer values to a given array
+ * control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayI32(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int32_t* array,
+                                   size_t         size);
+
+/**
+ * Writes an entire array of unsigned 32-bit integer values to a given array
+ * control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayU32(NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint32_t* array,
+                                   size_t          size);
+
+/**
+ * Writes an entire array of signed 64-bit integer values to a given array
+ * control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayI64(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const int64_t* array,
+                                   size_t         size);
+
+/**
+ * Writes an entire array of unsigned 64-bit integer values to a given array
+ * control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayU64(NiFpga_Session  session,
+                                   uint32_t        control,
+                                   const uint64_t* array,
+                                   size_t          size);
+
+/**
+ * Writes an entire array of single-precision floating-point values to a given
+ * array control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArraySgl(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const float*   array,
+                                   size_t         size);
+
+/**
+ * Writes an entire array of double-precision floating-point values to a given
+ * array control or indicator.
+ *
+ * @warning The size passed must be the exact number of elements in the
+ *          control or indicator.
+ *
+ * @param session handle to a currently open session
+ * @param control control or indicator to which to write
+ * @param array entire array to write
+ * @param size exact number of elements in the control or indicator
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteArrayDbl(NiFpga_Session session,
+                                   uint32_t       control,
+                                   const double*  array,
+                                   size_t         size);
+
+/**
+ * Enumeration of all 32 possible IRQs. Multiple IRQs can be bitwise ORed
+ * together like this:
+ *
+ *    NiFpga_Irq_3 | NiFpga_Irq_23
+ */
+typedef enum
+{
+   NiFpga_Irq_0  = 1 << 0,
+   NiFpga_Irq_1  = 1 << 1,
+   NiFpga_Irq_2  = 1 << 2,
+   NiFpga_Irq_3  = 1 << 3,
+   NiFpga_Irq_4  = 1 << 4,
+   NiFpga_Irq_5  = 1 << 5,
+   NiFpga_Irq_6  = 1 << 6,
+   NiFpga_Irq_7  = 1 << 7,
+   NiFpga_Irq_8  = 1 << 8,
+   NiFpga_Irq_9  = 1 << 9,
+   NiFpga_Irq_10 = 1 << 10,
+   NiFpga_Irq_11 = 1 << 11,
+   NiFpga_Irq_12 = 1 << 12,
+   NiFpga_Irq_13 = 1 << 13,
+   NiFpga_Irq_14 = 1 << 14,
+   NiFpga_Irq_15 = 1 << 15,
+   NiFpga_Irq_16 = 1 << 16,
+   NiFpga_Irq_17 = 1 << 17,
+   NiFpga_Irq_18 = 1 << 18,
+   NiFpga_Irq_19 = 1 << 19,
+   NiFpga_Irq_20 = 1 << 20,
+   NiFpga_Irq_21 = 1 << 21,
+   NiFpga_Irq_22 = 1 << 22,
+   NiFpga_Irq_23 = 1 << 23,
+   NiFpga_Irq_24 = 1 << 24,
+   NiFpga_Irq_25 = 1 << 25,
+   NiFpga_Irq_26 = 1 << 26,
+   NiFpga_Irq_27 = 1 << 27,
+   NiFpga_Irq_28 = 1 << 28,
+   NiFpga_Irq_29 = 1 << 29,
+   NiFpga_Irq_30 = 1 << 30,
+   NiFpga_Irq_31 = 1U << 31
+} NiFpga_Irq;
+
+/**
+ * Represents an infinite timeout.
+ */
+static const uint32_t NiFpga_InfiniteTimeout = 0xFFFFFFFF;
+
+/**
+ * See NiFpga_ReserveIrqContext for more information.
+ */
+typedef void* NiFpga_IrqContext;
+
+/**
+ * IRQ contexts are single-threaded; only one thread can wait with a
+ * particular context at any given time. To minimize jitter when first
+ * waiting on IRQs, reserve as many contexts as the application
+ * requires.
+ *
+ * If a context is successfully reserved (the returned status is not an error),
+ * it must be unreserved later. Otherwise a memory leak will occur.
+ *
+ * @param session handle to a currently open session
+ * @param context outputs the IRQ context
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReserveIrqContext(NiFpga_Session     session,
+                                       NiFpga_IrqContext* context);
+
+/**
+ * Unreserves an IRQ context obtained from NiFpga_ReserveIrqContext.
+ *
+ * @param session handle to a currently open session
+ * @param context IRQ context to unreserve
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_UnreserveIrqContext(NiFpga_Session    session,
+                                         NiFpga_IrqContext context);
+
+/**
+ * This is a blocking function that stops the calling thread until the
+ * FPGA asserts any IRQ in the irqs parameter, or until the function
+ * call times out.  Before calling this function, use
+ * NiFpga_ReserveIrqContext to reserve an IRQ context. No other
+ * threads can use the same context when this function is called.
+ *
+ * You can use the irqsAsserted parameter to determine which IRQs were asserted
+ * for each function call.
+ *
+ * @param session handle to a currently open session
+ * @param context IRQ context with which to wait
+ * @param irqs bitwise OR of NiFpga_Irqs
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param irqsAsserted if non-NULL, outputs bitwise OR of IRQs that were
+ *                     asserted
+ * @param timedOut if non-NULL, outputs whether the timeout expired
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WaitOnIrqs(NiFpga_Session    session,
+                                NiFpga_IrqContext context,
+                                uint32_t          irqs,
+                                uint32_t          timeout,
+                                uint32_t*         irqsAsserted,
+                                NiFpga_Bool*      timedOut);
+
+/**
+ * Acknowledges an IRQ or set of IRQs.
+ *
+ * @param session handle to a currently open session
+ * @param irqs bitwise OR of NiFpga_Irqs
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcknowledgeIrqs(NiFpga_Session session,
+                                     uint32_t       irqs);
+
+/**
+ * Specifies the depth of the host memory part of the DMA FIFO. This method is
+ * optional. In order to see the actual depth configured, use
+ * NiFpga_ConfigureFifo2.
+ *
+ * @param session handle to a currently open session
+ * @param fifo FIFO to configure
+ * @param depth requested number of elements in the host memory part of the
+ *              DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ConfigureFifo(NiFpga_Session session,
+                                   uint32_t       fifo,
+                                   size_t         depth);
+
+/**
+ * Specifies the depth of the host memory part of the DMA FIFO. This method is
+ * optional.
+ *
+ * @param session handle to a currently open session
+ * @param fifo FIFO to configure
+ * @param requestedDepth requested number of elements in the host memory part
+ *                       of the DMA FIFO
+ * @param actualDepth if non-NULL, outputs the actual number of elements in the
+ *                    host memory part of the DMA FIFO, which may be more than
+ *                    the requested number
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ConfigureFifo2(NiFpga_Session session,
+                                    uint32_t       fifo,
+                                    size_t         requestedDepth,
+                                    size_t*        actualDepth);
+
+/**
+ * Starts a FIFO. This method is optional.
+ *
+ * @param session handle to a currently open session
+ * @param fifo FIFO to start
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_StartFifo(NiFpga_Session session,
+                               uint32_t       fifo);
+
+/**
+ * Stops a FIFO. This method is optional.
+ *
+ * @param session handle to a currently open session
+ * @param fifo FIFO to stop
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_StopFifo(NiFpga_Session session,
+                              uint32_t       fifo);
+
+/**
+ * Reads from a target-to-host FIFO of booleans.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoBool(NiFpga_Session session,
+                                  uint32_t       fifo,
+                                  NiFpga_Bool*   data,
+                                  size_t         numberOfElements,
+                                  uint32_t       timeout,
+                                  size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of signed 8-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoI8(NiFpga_Session session,
+                                uint32_t       fifo,
+                                int8_t*        data,
+                                size_t         numberOfElements,
+                                uint32_t       timeout,
+                                size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of unsigned 8-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoU8(NiFpga_Session session,
+                                uint32_t       fifo,
+                                uint8_t*       data,
+                                size_t         numberOfElements,
+                                uint32_t       timeout,
+                                size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of signed 16-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoI16(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int16_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of unsigned 16-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoU16(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint16_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of signed 32-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoI32(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int32_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of unsigned 32-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoU32(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint32_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of signed 64-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoI64(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 int64_t*       data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of unsigned 64-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoU64(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 uint64_t*      data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of single-precision floating-point values.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoSgl(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 float*         data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining);
+
+/**
+ * Reads from a target-to-host FIFO of double-precision floating-point values.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param data outputs the data that was read
+ * @param numberOfElements number of elements to read
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReadFifoDbl(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 double*        data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        elementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of booleans.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoBool(NiFpga_Session     session,
+                                   uint32_t           fifo,
+                                   const NiFpga_Bool* data,
+                                   size_t             numberOfElements,
+                                   uint32_t           timeout,
+                                   size_t*            emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of signed 8-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoI8(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const int8_t*  data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of unsigned 8-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoU8(NiFpga_Session session,
+                                 uint32_t       fifo,
+                                 const uint8_t* data,
+                                 size_t         numberOfElements,
+                                 uint32_t       timeout,
+                                 size_t*        emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of signed 16-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoI16(NiFpga_Session session,
+                                  uint32_t       fifo,
+                                  const int16_t* data,
+                                  size_t         numberOfElements,
+                                  uint32_t       timeout,
+                                  size_t*        emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of unsigned 16-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoU16(NiFpga_Session  session,
+                                  uint32_t        fifo,
+                                  const uint16_t* data,
+                                  size_t          numberOfElements,
+                                  uint32_t        timeout,
+                                  size_t*         emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of signed 32-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoI32(NiFpga_Session session,
+                                  uint32_t       fifo,
+                                  const int32_t* data,
+                                  size_t         numberOfElements,
+                                  uint32_t       timeout,
+                                  size_t*        emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of unsigned 32-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoU32(NiFpga_Session  session,
+                                  uint32_t        fifo,
+                                  const uint32_t* data,
+                                  size_t          numberOfElements,
+                                  uint32_t        timeout,
+                                  size_t*         emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of signed 64-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoI64(NiFpga_Session session,
+                                  uint32_t       fifo,
+                                  const int64_t* data,
+                                  size_t         numberOfElements,
+                                  uint32_t       timeout,
+                                  size_t*        emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of unsigned 64-bit integers.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoU64(NiFpga_Session  session,
+                                  uint32_t        fifo,
+                                  const uint64_t* data,
+                                  size_t          numberOfElements,
+                                  uint32_t        timeout,
+                                  size_t*         emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of single-precision floating-point values.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoSgl(NiFpga_Session session,
+                                  uint32_t       fifo,
+                                  const float*   data,
+                                  size_t         numberOfElements,
+                                  uint32_t       timeout,
+                                  size_t*        emptyElementsRemaining);
+
+/**
+ * Writes to a host-to-target FIFO of double-precision floating-point values.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param data data to write
+ * @param numberOfElements number of elements to write
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param emptyElementsRemaining if non-NULL, outputs the number of empty
+ *                               elements remaining in the host memory part of
+ *                               the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_WriteFifoDbl(NiFpga_Session session,
+                                  uint32_t       fifo,
+                                  const double*  data,
+                                  size_t         numberOfElements,
+                                  uint32_t       timeout,
+                                  size_t*        emptyElementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of booleans.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsBool(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             NiFpga_Bool**  elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of signed 8-bit
+ * integers.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsI8(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             int8_t**       elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of unsigned 8-bit
+ * integers.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsU8(
+                                            NiFpga_Session  session,
+                                            uint32_t        fifo,
+                                            uint8_t**       elements,
+                                            size_t          elementsRequested,
+                                            uint32_t        timeout,
+                                            size_t*         elementsAcquired,
+                                            size_t*         elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of signed 16-bit
+ * integers.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsI16(
+                                            NiFpga_Session  session,
+                                            uint32_t        fifo,
+                                            int16_t**       elements,
+                                            size_t          elementsRequested,
+                                            uint32_t        timeout,
+                                            size_t*         elementsAcquired,
+                                            size_t*         elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of unsigned 16-bit
+ * integers.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsU16(
+                                           NiFpga_Session   session,
+                                           uint32_t         fifo,
+                                           uint16_t**       elements,
+                                           size_t           elementsRequested,
+                                           uint32_t         timeout,
+                                           size_t*          elementsAcquired,
+                                           size_t*          elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of signed 32-bit
+ * integers.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsI32(
+                                            NiFpga_Session  session,
+                                            uint32_t        fifo,
+                                            int32_t**       elements,
+                                            size_t          elementsRequested,
+                                            uint32_t        timeout,
+                                            size_t*         elementsAcquired,
+                                            size_t*         elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of unsigned 32-bit
+ * integers.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsU32(
+                                           NiFpga_Session   session,
+                                           uint32_t         fifo,
+                                           uint32_t**       elements,
+                                           size_t           elementsRequested,
+                                           uint32_t         timeout,
+                                           size_t*          elementsAcquired,
+                                           size_t*          elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of signed 64-bit
+ * integers.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsI64(
+                                            NiFpga_Session  session,
+                                            uint32_t        fifo,
+                                            int64_t**       elements,
+                                            size_t          elementsRequested,
+                                            uint32_t        timeout,
+                                            size_t*         elementsAcquired,
+                                            size_t*         elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of unsigned 64-bit
+ * integers.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsU64(
+                                           NiFpga_Session   session,
+                                           uint32_t         fifo,
+                                           uint64_t**       elements,
+                                           size_t           elementsRequested,
+                                           uint32_t         timeout,
+                                           size_t*          elementsAcquired,
+                                           size_t*          elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of single-precision
+ * floating-point values.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsSgl(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             float**        elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for reading from a target-to-host FIFO of double-precision
+ * floating-point values.
+ *
+ * Acquiring, reading, and releasing FIFO elements prevents the need to copy
+ * the contents of elements from the host memory buffer to a separate
+ * user-allocated buffer before reading. The FPGA target cannot write to
+ * elements acquired by the host. Therefore, the host must release elements
+ * after reading them. The number of elements acquired may differ from the
+ * number of elements requested if, for example, the number of elements
+ * requested reaches the end of the host memory buffer. Always release all
+ * acquired elements before closing the session. Do not attempt to access FIFO
+ * elements after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo target-to-host FIFO from which to read
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoReadElementsDbl(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             double**       elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of booleans.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsBool(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             NiFpga_Bool**  elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of signed 8-bit
+ * integers.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI8(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             int8_t**       elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of unsigned 8-bit
+ * integers.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU8(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             uint8_t**      elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of signed 16-bit
+ * integers.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI16(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             int16_t**      elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of unsigned 16-bit
+ * integers.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU16(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             uint16_t**     elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of signed 32-bit
+ * integers.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI32(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             int32_t**      elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of unsigned 32-bit
+ * integers.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU32(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             uint32_t**     elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of signed 64-bit
+ * integers.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI64(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             int64_t**      elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of unsigned 64-bit
+ * integers.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU64(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             uint64_t**     elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of single-precision
+ * floating-point values.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsSgl(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             float**        elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Acquires elements for writing to a host-to-target FIFO of single-precision
+ * floating-point values.
+ *
+ * Acquiring, writing, and releasing FIFO elements prevents the need to write
+ * first into a separate user-allocated buffer and then copy the contents of
+ * elements to the host memory buffer. The FPGA target cannot read elements
+ * acquired by the host. Therefore, the host must release elements after
+ * writing to them. The number of elements acquired may differ from the number
+ * of elements requested if, for example, the number of elements requested
+ * reaches the end of the host memory buffer. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo host-to-target FIFO to which to write
+ * @param elements outputs a pointer to the elements acquired
+ * @param elementsRequested requested number of elements
+ * @param timeout timeout in milliseconds, or NiFpga_InfiniteTimeout
+ * @param elementsAcquired actual number of elements acquired, which may be
+ *                         less than the requested number
+ * @param elementsRemaining if non-NULL, outputs the number of elements
+ *                          remaining in the host memory part of the DMA FIFO
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_AcquireFifoWriteElementsDbl(
+                                             NiFpga_Session session,
+                                             uint32_t       fifo,
+                                             double**       elements,
+                                             size_t         elementsRequested,
+                                             uint32_t       timeout,
+                                             size_t*        elementsAcquired,
+                                             size_t*        elementsRemaining);
+
+/**
+ * Releases previously acquired FIFO elements.
+ *
+ * The FPGA target cannot read elements acquired by the host. Therefore, the
+ * host must release elements after acquiring them. Always release all acquired
+ * elements before closing the session. Do not attempt to access FIFO elements
+ * after the elements are released or the session is closed.
+ *
+ * @param session handle to a currently open session
+ * @param fifo FIFO from which to release elements
+ * @param elements number of elements to release
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_ReleaseFifoElements(NiFpga_Session session,
+                                         uint32_t       fifo,
+                                         size_t         elements);
+
+/**
+ * Gets an endpoint reference to a peer-to-peer FIFO.
+ *
+ * @param session handle to a currently open session
+ * @param fifo peer-to-peer FIFO
+ * @param endpoint Outputs the endpoint reference.
+ *                 The actual type is a nip2p_tEndpointHandle usable by
+ *                 the NI Peer-to-Peer Streaming C/C++ API.
+ * @return result of the call
+ */
+NiFpga_Status NiFpga_GetPeerToPeerFifoEndpoint(NiFpga_Session session,
+                                               uint32_t       fifo,
+                                               uint32_t*      endpoint);
+
+#if NiFpga_Cpp
+}
+#endif
+
+#endif

--- a/nifpga_shim/NiFpga_shim.c
+++ b/nifpga_shim/NiFpga_shim.c
@@ -1,0 +1,1015 @@
+#include <stdio.h>
+
+#include "NiFpga.h"
+
+NiFpga_Status NiFpga_Initialize() {
+	printf("NiFpga_Initialize");
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_Finalize() {
+	printf("NiFpga_Finalize");
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_Open(const char * bitfile, const char * signature, const char * resource, uint32_t attribute, NiFpga_Session * session) {
+	printf("NiFpga_Open");
+	printf("\tbitfile = %p", bitfile);
+	printf("\tsignature = %p", signature);
+	printf("\tresource = %p", resource);
+	printf("\tattribute = %d", attribute);
+	printf("\tsession = %p", session);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_Close(NiFpga_Session session, uint32_t attribute) {
+	printf("NiFpga_Close");
+	printf("\tsession = %d", session);
+	printf("\tattribute = %d", attribute);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_Run(NiFpga_Session session, uint32_t attribute) {
+	printf("NiFpga_Run");
+	printf("\tsession = %d", session);
+	printf("\tattribute = %d", attribute);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_Abort(NiFpga_Session session) {
+	printf("NiFpga_Abort");
+	printf("\tsession = %d", session);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_Reset(NiFpga_Session session) {
+	printf("NiFpga_Reset");
+	printf("\tsession = %d", session);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_Download(NiFpga_Session session) {
+	printf("NiFpga_Download");
+	printf("\tsession = %d", session);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadBool(NiFpga_Session session, uint32_t indicator, NiFpga_Bool * value) {
+	printf("NiFpga_ReadBool");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tvalue = %p", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadI8(NiFpga_Session session, uint32_t indicator, int8_t * value) {
+	printf("NiFpga_ReadI8");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tvalue = %p", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadU8(NiFpga_Session session, uint32_t indicator, uint8_t * value) {
+	printf("NiFpga_ReadU8");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tvalue = %p", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadI16(NiFpga_Session session, uint32_t indicator, int16_t * value) {
+	printf("NiFpga_ReadI16");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tvalue = %p", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadU16(NiFpga_Session session, uint32_t indicator, uint16_t * value) {
+	printf("NiFpga_ReadU16");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tvalue = %p", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadI32(NiFpga_Session session, uint32_t indicator, int32_t * value) {
+	printf("NiFpga_ReadI32");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tvalue = %p", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadU32(NiFpga_Session session, uint32_t indicator, uint32_t * value) {
+	printf("NiFpga_ReadU32");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tvalue = %p", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadI64(NiFpga_Session session, uint32_t indicator, int64_t * value) {
+	printf("NiFpga_ReadI64");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tvalue = %p", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadU64(NiFpga_Session session, uint32_t indicator, uint64_t * value) {
+	printf("NiFpga_ReadU64");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tvalue = %p", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadSgl(NiFpga_Session session, uint32_t indicator, float * value) {
+	printf("NiFpga_ReadSgl");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tvalue = %p", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadDbl(NiFpga_Session session, uint32_t indicator, double * value) {
+	printf("NiFpga_ReadDbl");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tvalue = %p", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteBool(NiFpga_Session session, uint32_t control, NiFpga_Bool value) {
+	printf("NiFpga_WriteBool");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tvalue = %d", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteI8(NiFpga_Session session, uint32_t control, int8_t value) {
+	printf("NiFpga_WriteI8");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tvalue = %d", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteU8(NiFpga_Session session, uint32_t control, uint8_t value) {
+	printf("NiFpga_WriteU8");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tvalue = %d", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteI16(NiFpga_Session session, uint32_t control, int16_t value) {
+	printf("NiFpga_WriteI16");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tvalue = %d", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteU16(NiFpga_Session session, uint32_t control, uint16_t value) {
+	printf("NiFpga_WriteU16");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tvalue = %d", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteI32(NiFpga_Session session, uint32_t control, int32_t value) {
+	printf("NiFpga_WriteI32");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tvalue = %d", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteU32(NiFpga_Session session, uint32_t control, uint32_t value) {
+	printf("NiFpga_WriteU32");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tvalue = %d", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteI64(NiFpga_Session session, uint32_t control, int64_t value) {
+	printf("NiFpga_WriteI64");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tvalue = %d", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteU64(NiFpga_Session session, uint32_t control, uint64_t value) {
+	printf("NiFpga_WriteU64");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tvalue = %d", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteSgl(NiFpga_Session session, uint32_t control, float value) {
+	printf("NiFpga_WriteSgl");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tvalue = %f", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteDbl(NiFpga_Session session, uint32_t control, double value) {
+	printf("NiFpga_WriteDbl");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tvalue = %f", value);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadArrayBool(NiFpga_Session session, uint32_t indicator, NiFpga_Bool * array, size_t size) {
+	printf("NiFpga_ReadArrayBool");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadArrayI8(NiFpga_Session session, uint32_t indicator, int8_t * array, size_t size) {
+	printf("NiFpga_ReadArrayI8");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadArrayU8(NiFpga_Session session, uint32_t indicator, uint8_t * array, size_t size) {
+	printf("NiFpga_ReadArrayU8");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadArrayI16(NiFpga_Session session, uint32_t indicator, int16_t * array, size_t size) {
+	printf("NiFpga_ReadArrayI16");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadArrayU16(NiFpga_Session session, uint32_t indicator, uint16_t * array, size_t size) {
+	printf("NiFpga_ReadArrayU16");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadArrayI32(NiFpga_Session session, uint32_t indicator, int32_t * array, size_t size) {
+	printf("NiFpga_ReadArrayI32");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadArrayU32(NiFpga_Session session, uint32_t indicator, uint32_t * array, size_t size) {
+	printf("NiFpga_ReadArrayU32");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadArrayI64(NiFpga_Session session, uint32_t indicator, int64_t * array, size_t size) {
+	printf("NiFpga_ReadArrayI64");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadArrayU64(NiFpga_Session session, uint32_t indicator, uint64_t * array, size_t size) {
+	printf("NiFpga_ReadArrayU64");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadArraySgl(NiFpga_Session session, uint32_t indicator, float * array, size_t size) {
+	printf("NiFpga_ReadArraySgl");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadArrayDbl(NiFpga_Session session, uint32_t indicator, double * array, size_t size) {
+	printf("NiFpga_ReadArrayDbl");
+	printf("\tsession = %d", session);
+	printf("\tindicator = %d", indicator);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteArrayBool(NiFpga_Session session, uint32_t control, const NiFpga_Bool * array, size_t size) {
+	printf("NiFpga_WriteArrayBool");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteArrayI8(NiFpga_Session session, uint32_t control, const int8_t * array, size_t size) {
+	printf("NiFpga_WriteArrayI8");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteArrayU8(NiFpga_Session session, uint32_t control, const uint8_t * array, size_t size) {
+	printf("NiFpga_WriteArrayU8");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteArrayI16(NiFpga_Session session, uint32_t control, const int16_t * array, size_t size) {
+	printf("NiFpga_WriteArrayI16");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteArrayU16(NiFpga_Session session, uint32_t control, const uint16_t * array, size_t size) {
+	printf("NiFpga_WriteArrayU16");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteArrayI32(NiFpga_Session session, uint32_t control, const int32_t * array, size_t size) {
+	printf("NiFpga_WriteArrayI32");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteArrayU32(NiFpga_Session session, uint32_t control, const uint32_t * array, size_t size) {
+	printf("NiFpga_WriteArrayU32");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteArrayI64(NiFpga_Session session, uint32_t control, const int64_t * array, size_t size) {
+	printf("NiFpga_WriteArrayI64");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteArrayU64(NiFpga_Session session, uint32_t control, const uint64_t * array, size_t size) {
+	printf("NiFpga_WriteArrayU64");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteArraySgl(NiFpga_Session session, uint32_t control, const float * array, size_t size) {
+	printf("NiFpga_WriteArraySgl");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteArrayDbl(NiFpga_Session session, uint32_t control, const double * array, size_t size) {
+	printf("NiFpga_WriteArrayDbl");
+	printf("\tsession = %d", session);
+	printf("\tcontrol = %d", control);
+	printf("\tarray = %p", array);
+	printf("\tsize = %d", size);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReserveIrqContext(NiFpga_Session session, NiFpga_IrqContext * context) {
+	printf("NiFpga_ReserveIrqContext");
+	printf("\tsession = %d", session);
+	printf("\tcontext = %p", context);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_UnreserveIrqContext(NiFpga_Session session, NiFpga_IrqContext context) {
+	printf("NiFpga_UnreserveIrqContext");
+	printf("\tsession = %d", session);
+	printf("\tcontext = %d", context);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WaitOnIrqs(NiFpga_Session session, NiFpga_IrqContext context, uint32_t irqs, uint32_t timeout, uint32_t * irqsAsserted, NiFpga_Bool * timedOut) {
+	printf("NiFpga_WaitOnIrqs");
+	printf("\tsession = %d", session);
+	printf("\tcontext = %d", context);
+	printf("\tirqs = %d", irqs);
+	printf("\ttimeout = %d", timeout);
+	printf("\tirqsAsserted = %p", irqsAsserted);
+	printf("\ttimedOut = %p", timedOut);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcknowledgeIrqs(NiFpga_Session session, uint32_t irqs) {
+	printf("NiFpga_AcknowledgeIrqs");
+	printf("\tsession = %d", session);
+	printf("\tirqs = %d", irqs);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ConfigureFifo(NiFpga_Session session, uint32_t fifo, size_t depth) {
+	printf("NiFpga_ConfigureFifo");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdepth = %d", depth);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ConfigureFifo2(NiFpga_Session session, uint32_t fifo, size_t requestedDepth, size_t * actualDepth) {
+	printf("NiFpga_ConfigureFifo2");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\trequestedDepth = %d", requestedDepth);
+	printf("\tactualDepth = %p", actualDepth);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_StartFifo(NiFpga_Session session, uint32_t fifo) {
+	printf("NiFpga_StartFifo");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_StopFifo(NiFpga_Session session, uint32_t fifo) {
+	printf("NiFpga_StopFifo");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadFifoBool(NiFpga_Session session, uint32_t fifo, NiFpga_Bool * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+	printf("NiFpga_ReadFifoBool");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadFifoI8(NiFpga_Session session, uint32_t fifo, int8_t * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+	printf("NiFpga_ReadFifoI8");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadFifoU8(NiFpga_Session session, uint32_t fifo, uint8_t * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+	printf("NiFpga_ReadFifoU8");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadFifoI16(NiFpga_Session session, uint32_t fifo, int16_t * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+	printf("NiFpga_ReadFifoI16");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadFifoU16(NiFpga_Session session, uint32_t fifo, uint16_t * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+	printf("NiFpga_ReadFifoU16");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadFifoI32(NiFpga_Session session, uint32_t fifo, int32_t * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+	printf("NiFpga_ReadFifoI32");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadFifoU32(NiFpga_Session session, uint32_t fifo, uint32_t * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+	printf("NiFpga_ReadFifoU32");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadFifoI64(NiFpga_Session session, uint32_t fifo, int64_t * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+	printf("NiFpga_ReadFifoI64");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadFifoU64(NiFpga_Session session, uint32_t fifo, uint64_t * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+	printf("NiFpga_ReadFifoU64");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadFifoSgl(NiFpga_Session session, uint32_t fifo, float * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+	printf("NiFpga_ReadFifoSgl");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReadFifoDbl(NiFpga_Session session, uint32_t fifo, double * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+	printf("NiFpga_ReadFifoDbl");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteFifoBool(NiFpga_Session session, uint32_t fifo, const NiFpga_Bool * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+	printf("NiFpga_WriteFifoBool");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\temptyElementsRemaining = %p", emptyElementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteFifoI8(NiFpga_Session session, uint32_t fifo, const int8_t * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+	printf("NiFpga_WriteFifoI8");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\temptyElementsRemaining = %p", emptyElementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteFifoU8(NiFpga_Session session, uint32_t fifo, const uint8_t * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+	printf("NiFpga_WriteFifoU8");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\temptyElementsRemaining = %p", emptyElementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteFifoI16(NiFpga_Session session, uint32_t fifo, const int16_t * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+	printf("NiFpga_WriteFifoI16");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\temptyElementsRemaining = %p", emptyElementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteFifoU16(NiFpga_Session session, uint32_t fifo, const uint16_t * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+	printf("NiFpga_WriteFifoU16");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\temptyElementsRemaining = %p", emptyElementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteFifoI32(NiFpga_Session session, uint32_t fifo, const int32_t * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+	printf("NiFpga_WriteFifoI32");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\temptyElementsRemaining = %p", emptyElementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteFifoU32(NiFpga_Session session, uint32_t fifo, const uint32_t * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+	printf("NiFpga_WriteFifoU32");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\temptyElementsRemaining = %p", emptyElementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteFifoI64(NiFpga_Session session, uint32_t fifo, const int64_t * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+	printf("NiFpga_WriteFifoI64");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\temptyElementsRemaining = %p", emptyElementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteFifoU64(NiFpga_Session session, uint32_t fifo, const uint64_t * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+	printf("NiFpga_WriteFifoU64");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\temptyElementsRemaining = %p", emptyElementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteFifoSgl(NiFpga_Session session, uint32_t fifo, const float * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+	printf("NiFpga_WriteFifoSgl");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\temptyElementsRemaining = %p", emptyElementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_WriteFifoDbl(NiFpga_Session session, uint32_t fifo, const double * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+	printf("NiFpga_WriteFifoDbl");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tdata = %p", data);
+	printf("\tnumberOfElements = %d", numberOfElements);
+	printf("\ttimeout = %d", timeout);
+	printf("\temptyElementsRemaining = %p", emptyElementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsBool(NiFpga_Session session, uint32_t fifo, NiFpga_Bool ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoReadElementsBool");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsI8(NiFpga_Session session, uint32_t fifo, int8_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoReadElementsI8");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsU8(NiFpga_Session session, uint32_t fifo, uint8_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoReadElementsU8");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsI16(NiFpga_Session session, uint32_t fifo, int16_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoReadElementsI16");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsU16(NiFpga_Session session, uint32_t fifo, uint16_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoReadElementsU16");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsI32(NiFpga_Session session, uint32_t fifo, int32_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoReadElementsI32");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsU32(NiFpga_Session session, uint32_t fifo, uint32_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoReadElementsU32");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsI64(NiFpga_Session session, uint32_t fifo, int64_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoReadElementsI64");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsU64(NiFpga_Session session, uint32_t fifo, uint64_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoReadElementsU64");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsSgl(NiFpga_Session session, uint32_t fifo, float ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoReadElementsSgl");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoReadElementsDbl(NiFpga_Session session, uint32_t fifo, double ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoReadElementsDbl");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsBool(NiFpga_Session session, uint32_t fifo, NiFpga_Bool ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoWriteElementsBool");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI8(NiFpga_Session session, uint32_t fifo, int8_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoWriteElementsI8");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU8(NiFpga_Session session, uint32_t fifo, uint8_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoWriteElementsU8");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI16(NiFpga_Session session, uint32_t fifo, int16_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoWriteElementsI16");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU16(NiFpga_Session session, uint32_t fifo, uint16_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoWriteElementsU16");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI32(NiFpga_Session session, uint32_t fifo, int32_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoWriteElementsI32");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU32(NiFpga_Session session, uint32_t fifo, uint32_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoWriteElementsU32");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsI64(NiFpga_Session session, uint32_t fifo, int64_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoWriteElementsI64");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsU64(NiFpga_Session session, uint32_t fifo, uint64_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoWriteElementsU64");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsSgl(NiFpga_Session session, uint32_t fifo, float ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoWriteElementsSgl");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_AcquireFifoWriteElementsDbl(NiFpga_Session session, uint32_t fifo, double ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+	printf("NiFpga_AcquireFifoWriteElementsDbl");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %p", elements);
+	printf("\telementsRequested = %d", elementsRequested);
+	printf("\ttimeout = %d", timeout);
+	printf("\telementsAcquired = %p", elementsAcquired);
+	printf("\telementsRemaining = %p", elementsRemaining);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_ReleaseFifoElements(NiFpga_Session session, uint32_t fifo, size_t elements) {
+	printf("NiFpga_ReleaseFifoElements");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\telements = %d", elements);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpga_GetPeerToPeerFifoEndpoint(NiFpga_Session session, uint32_t fifo, uint32_t * endpoint) {
+	printf("NiFpga_GetPeerToPeerFifoEndpoint");
+	printf("\tsession = %d", session);
+	printf("\tfifo = %d", fifo);
+	printf("\tendpoint = %p", endpoint);
+	return NiFpga_Status_Success;
+}
+

--- a/nifpga_shim/NiFpga_shim.c
+++ b/nifpga_shim/NiFpga_shim.c
@@ -1,18 +1,36 @@
+#include "NiFpga.h"
 #include <stdio.h>
 
-#include "NiFpga.h"
+NiFpga_Bool NiFpgaDll_IsError(const NiFpga_Status status) {
+	printf("NiFpga_IsError");
+	printf("\tstatus = %d", status);
+	return NiFpga_Status_Success;
+}
 
-NiFpga_Status NiFpga_Initialize() {
+NiFpga_Bool NiFpgaDll_IsNotError(const NiFpga_Status status) {
+	printf("NiFpga_IsNotError");
+	printf("\tstatus = %d", status);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpgaDll_MergeStatus(NiFpga_Status *const status, const NiFpga_Status newStatus) {
+	printf("NiFpga_MergeStatus");
+	printf("\tstatus = %p", status);
+	printf("\tnewStatus = %d", newStatus);
+	return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpgaDll_Initialize() {
 	printf("NiFpga_Initialize");
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_Finalize() {
+NiFpga_Status NiFpgaDll_Finalize() {
 	printf("NiFpga_Finalize");
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_Open(const char * bitfile, const char * signature, const char * resource, uint32_t attribute, NiFpga_Session * session) {
+NiFpga_Status NiFpgaDll_Open(const char * bitfile, const char * signature, const char * resource, uint32_t attribute, NiFpga_Session * session) {
 	printf("NiFpga_Open");
 	printf("\tbitfile = %p", bitfile);
 	printf("\tsignature = %p", signature);
@@ -22,39 +40,39 @@ NiFpga_Status NiFpga_Open(const char * bitfile, const char * signature, const ch
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_Close(NiFpga_Session session, uint32_t attribute) {
+NiFpga_Status NiFpgaDll_Close(NiFpga_Session session, uint32_t attribute) {
 	printf("NiFpga_Close");
 	printf("\tsession = %d", session);
 	printf("\tattribute = %d", attribute);
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_Run(NiFpga_Session session, uint32_t attribute) {
+NiFpga_Status NiFpgaDll_Run(NiFpga_Session session, uint32_t attribute) {
 	printf("NiFpga_Run");
 	printf("\tsession = %d", session);
 	printf("\tattribute = %d", attribute);
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_Abort(NiFpga_Session session) {
+NiFpga_Status NiFpgaDll_Abort(NiFpga_Session session) {
 	printf("NiFpga_Abort");
 	printf("\tsession = %d", session);
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_Reset(NiFpga_Session session) {
+NiFpga_Status NiFpgaDll_Reset(NiFpga_Session session) {
 	printf("NiFpga_Reset");
 	printf("\tsession = %d", session);
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_Download(NiFpga_Session session) {
+NiFpga_Status NiFpgaDll_Download(NiFpga_Session session) {
 	printf("NiFpga_Download");
 	printf("\tsession = %d", session);
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadBool(NiFpga_Session session, uint32_t indicator, NiFpga_Bool * value) {
+NiFpga_Status NiFpgaDll_ReadBool(NiFpga_Session session, uint32_t indicator, NiFpga_Bool * value) {
 	printf("NiFpga_ReadBool");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -62,7 +80,7 @@ NiFpga_Status NiFpga_ReadBool(NiFpga_Session session, uint32_t indicator, NiFpga
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadI8(NiFpga_Session session, uint32_t indicator, int8_t * value) {
+NiFpga_Status NiFpgaDll_ReadI8(NiFpga_Session session, uint32_t indicator, int8_t * value) {
 	printf("NiFpga_ReadI8");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -70,7 +88,7 @@ NiFpga_Status NiFpga_ReadI8(NiFpga_Session session, uint32_t indicator, int8_t *
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadU8(NiFpga_Session session, uint32_t indicator, uint8_t * value) {
+NiFpga_Status NiFpgaDll_ReadU8(NiFpga_Session session, uint32_t indicator, uint8_t * value) {
 	printf("NiFpga_ReadU8");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -78,7 +96,7 @@ NiFpga_Status NiFpga_ReadU8(NiFpga_Session session, uint32_t indicator, uint8_t 
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadI16(NiFpga_Session session, uint32_t indicator, int16_t * value) {
+NiFpga_Status NiFpgaDll_ReadI16(NiFpga_Session session, uint32_t indicator, int16_t * value) {
 	printf("NiFpga_ReadI16");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -86,7 +104,7 @@ NiFpga_Status NiFpga_ReadI16(NiFpga_Session session, uint32_t indicator, int16_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadU16(NiFpga_Session session, uint32_t indicator, uint16_t * value) {
+NiFpga_Status NiFpgaDll_ReadU16(NiFpga_Session session, uint32_t indicator, uint16_t * value) {
 	printf("NiFpga_ReadU16");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -94,7 +112,7 @@ NiFpga_Status NiFpga_ReadU16(NiFpga_Session session, uint32_t indicator, uint16_
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadI32(NiFpga_Session session, uint32_t indicator, int32_t * value) {
+NiFpga_Status NiFpgaDll_ReadI32(NiFpga_Session session, uint32_t indicator, int32_t * value) {
 	printf("NiFpga_ReadI32");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -102,7 +120,7 @@ NiFpga_Status NiFpga_ReadI32(NiFpga_Session session, uint32_t indicator, int32_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadU32(NiFpga_Session session, uint32_t indicator, uint32_t * value) {
+NiFpga_Status NiFpgaDll_ReadU32(NiFpga_Session session, uint32_t indicator, uint32_t * value) {
 	printf("NiFpga_ReadU32");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -110,7 +128,7 @@ NiFpga_Status NiFpga_ReadU32(NiFpga_Session session, uint32_t indicator, uint32_
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadI64(NiFpga_Session session, uint32_t indicator, int64_t * value) {
+NiFpga_Status NiFpgaDll_ReadI64(NiFpga_Session session, uint32_t indicator, int64_t * value) {
 	printf("NiFpga_ReadI64");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -118,7 +136,7 @@ NiFpga_Status NiFpga_ReadI64(NiFpga_Session session, uint32_t indicator, int64_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadU64(NiFpga_Session session, uint32_t indicator, uint64_t * value) {
+NiFpga_Status NiFpgaDll_ReadU64(NiFpga_Session session, uint32_t indicator, uint64_t * value) {
 	printf("NiFpga_ReadU64");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -126,7 +144,7 @@ NiFpga_Status NiFpga_ReadU64(NiFpga_Session session, uint32_t indicator, uint64_
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadSgl(NiFpga_Session session, uint32_t indicator, float * value) {
+NiFpga_Status NiFpgaDll_ReadSgl(NiFpga_Session session, uint32_t indicator, float * value) {
 	printf("NiFpga_ReadSgl");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -134,7 +152,7 @@ NiFpga_Status NiFpga_ReadSgl(NiFpga_Session session, uint32_t indicator, float *
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadDbl(NiFpga_Session session, uint32_t indicator, double * value) {
+NiFpga_Status NiFpgaDll_ReadDbl(NiFpga_Session session, uint32_t indicator, double * value) {
 	printf("NiFpga_ReadDbl");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -142,7 +160,7 @@ NiFpga_Status NiFpga_ReadDbl(NiFpga_Session session, uint32_t indicator, double 
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteBool(NiFpga_Session session, uint32_t control, NiFpga_Bool value) {
+NiFpga_Status NiFpgaDll_WriteBool(NiFpga_Session session, uint32_t control, NiFpga_Bool value) {
 	printf("NiFpga_WriteBool");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -150,7 +168,7 @@ NiFpga_Status NiFpga_WriteBool(NiFpga_Session session, uint32_t control, NiFpga_
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteI8(NiFpga_Session session, uint32_t control, int8_t value) {
+NiFpga_Status NiFpgaDll_WriteI8(NiFpga_Session session, uint32_t control, int8_t value) {
 	printf("NiFpga_WriteI8");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -158,7 +176,7 @@ NiFpga_Status NiFpga_WriteI8(NiFpga_Session session, uint32_t control, int8_t va
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteU8(NiFpga_Session session, uint32_t control, uint8_t value) {
+NiFpga_Status NiFpgaDll_WriteU8(NiFpga_Session session, uint32_t control, uint8_t value) {
 	printf("NiFpga_WriteU8");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -166,7 +184,7 @@ NiFpga_Status NiFpga_WriteU8(NiFpga_Session session, uint32_t control, uint8_t v
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteI16(NiFpga_Session session, uint32_t control, int16_t value) {
+NiFpga_Status NiFpgaDll_WriteI16(NiFpga_Session session, uint32_t control, int16_t value) {
 	printf("NiFpga_WriteI16");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -174,7 +192,7 @@ NiFpga_Status NiFpga_WriteI16(NiFpga_Session session, uint32_t control, int16_t 
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteU16(NiFpga_Session session, uint32_t control, uint16_t value) {
+NiFpga_Status NiFpgaDll_WriteU16(NiFpga_Session session, uint32_t control, uint16_t value) {
 	printf("NiFpga_WriteU16");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -182,7 +200,7 @@ NiFpga_Status NiFpga_WriteU16(NiFpga_Session session, uint32_t control, uint16_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteI32(NiFpga_Session session, uint32_t control, int32_t value) {
+NiFpga_Status NiFpgaDll_WriteI32(NiFpga_Session session, uint32_t control, int32_t value) {
 	printf("NiFpga_WriteI32");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -190,7 +208,7 @@ NiFpga_Status NiFpga_WriteI32(NiFpga_Session session, uint32_t control, int32_t 
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteU32(NiFpga_Session session, uint32_t control, uint32_t value) {
+NiFpga_Status NiFpgaDll_WriteU32(NiFpga_Session session, uint32_t control, uint32_t value) {
 	printf("NiFpga_WriteU32");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -198,7 +216,7 @@ NiFpga_Status NiFpga_WriteU32(NiFpga_Session session, uint32_t control, uint32_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteI64(NiFpga_Session session, uint32_t control, int64_t value) {
+NiFpga_Status NiFpgaDll_WriteI64(NiFpga_Session session, uint32_t control, int64_t value) {
 	printf("NiFpga_WriteI64");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -206,7 +224,7 @@ NiFpga_Status NiFpga_WriteI64(NiFpga_Session session, uint32_t control, int64_t 
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteU64(NiFpga_Session session, uint32_t control, uint64_t value) {
+NiFpga_Status NiFpgaDll_WriteU64(NiFpga_Session session, uint32_t control, uint64_t value) {
 	printf("NiFpga_WriteU64");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -214,7 +232,7 @@ NiFpga_Status NiFpga_WriteU64(NiFpga_Session session, uint32_t control, uint64_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteSgl(NiFpga_Session session, uint32_t control, float value) {
+NiFpga_Status NiFpgaDll_WriteSgl(NiFpga_Session session, uint32_t control, float value) {
 	printf("NiFpga_WriteSgl");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -222,7 +240,7 @@ NiFpga_Status NiFpga_WriteSgl(NiFpga_Session session, uint32_t control, float va
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteDbl(NiFpga_Session session, uint32_t control, double value) {
+NiFpga_Status NiFpgaDll_WriteDbl(NiFpga_Session session, uint32_t control, double value) {
 	printf("NiFpga_WriteDbl");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -230,7 +248,7 @@ NiFpga_Status NiFpga_WriteDbl(NiFpga_Session session, uint32_t control, double v
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadArrayBool(NiFpga_Session session, uint32_t indicator, NiFpga_Bool * array, size_t size) {
+NiFpga_Status NiFpgaDll_ReadArrayBool(NiFpga_Session session, uint32_t indicator, NiFpga_Bool * array, int size) {
 	printf("NiFpga_ReadArrayBool");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -239,7 +257,7 @@ NiFpga_Status NiFpga_ReadArrayBool(NiFpga_Session session, uint32_t indicator, N
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadArrayI8(NiFpga_Session session, uint32_t indicator, int8_t * array, size_t size) {
+NiFpga_Status NiFpgaDll_ReadArrayI8(NiFpga_Session session, uint32_t indicator, int8_t * array, int size) {
 	printf("NiFpga_ReadArrayI8");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -248,7 +266,7 @@ NiFpga_Status NiFpga_ReadArrayI8(NiFpga_Session session, uint32_t indicator, int
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadArrayU8(NiFpga_Session session, uint32_t indicator, uint8_t * array, size_t size) {
+NiFpga_Status NiFpgaDll_ReadArrayU8(NiFpga_Session session, uint32_t indicator, uint8_t * array, int size) {
 	printf("NiFpga_ReadArrayU8");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -257,7 +275,7 @@ NiFpga_Status NiFpga_ReadArrayU8(NiFpga_Session session, uint32_t indicator, uin
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadArrayI16(NiFpga_Session session, uint32_t indicator, int16_t * array, size_t size) {
+NiFpga_Status NiFpgaDll_ReadArrayI16(NiFpga_Session session, uint32_t indicator, int16_t * array, int size) {
 	printf("NiFpga_ReadArrayI16");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -266,7 +284,7 @@ NiFpga_Status NiFpga_ReadArrayI16(NiFpga_Session session, uint32_t indicator, in
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadArrayU16(NiFpga_Session session, uint32_t indicator, uint16_t * array, size_t size) {
+NiFpga_Status NiFpgaDll_ReadArrayU16(NiFpga_Session session, uint32_t indicator, uint16_t * array, int size) {
 	printf("NiFpga_ReadArrayU16");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -275,7 +293,7 @@ NiFpga_Status NiFpga_ReadArrayU16(NiFpga_Session session, uint32_t indicator, ui
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadArrayI32(NiFpga_Session session, uint32_t indicator, int32_t * array, size_t size) {
+NiFpga_Status NiFpgaDll_ReadArrayI32(NiFpga_Session session, uint32_t indicator, int32_t * array, int size) {
 	printf("NiFpga_ReadArrayI32");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -284,7 +302,7 @@ NiFpga_Status NiFpga_ReadArrayI32(NiFpga_Session session, uint32_t indicator, in
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadArrayU32(NiFpga_Session session, uint32_t indicator, uint32_t * array, size_t size) {
+NiFpga_Status NiFpgaDll_ReadArrayU32(NiFpga_Session session, uint32_t indicator, uint32_t * array, int size) {
 	printf("NiFpga_ReadArrayU32");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -293,7 +311,7 @@ NiFpga_Status NiFpga_ReadArrayU32(NiFpga_Session session, uint32_t indicator, ui
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadArrayI64(NiFpga_Session session, uint32_t indicator, int64_t * array, size_t size) {
+NiFpga_Status NiFpgaDll_ReadArrayI64(NiFpga_Session session, uint32_t indicator, int64_t * array, int size) {
 	printf("NiFpga_ReadArrayI64");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -302,7 +320,7 @@ NiFpga_Status NiFpga_ReadArrayI64(NiFpga_Session session, uint32_t indicator, in
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadArrayU64(NiFpga_Session session, uint32_t indicator, uint64_t * array, size_t size) {
+NiFpga_Status NiFpgaDll_ReadArrayU64(NiFpga_Session session, uint32_t indicator, uint64_t * array, int size) {
 	printf("NiFpga_ReadArrayU64");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -311,7 +329,7 @@ NiFpga_Status NiFpga_ReadArrayU64(NiFpga_Session session, uint32_t indicator, ui
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadArraySgl(NiFpga_Session session, uint32_t indicator, float * array, size_t size) {
+NiFpga_Status NiFpgaDll_ReadArraySgl(NiFpga_Session session, uint32_t indicator, float * array, int size) {
 	printf("NiFpga_ReadArraySgl");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -320,7 +338,7 @@ NiFpga_Status NiFpga_ReadArraySgl(NiFpga_Session session, uint32_t indicator, fl
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadArrayDbl(NiFpga_Session session, uint32_t indicator, double * array, size_t size) {
+NiFpga_Status NiFpgaDll_ReadArrayDbl(NiFpga_Session session, uint32_t indicator, double * array, int size) {
 	printf("NiFpga_ReadArrayDbl");
 	printf("\tsession = %d", session);
 	printf("\tindicator = %d", indicator);
@@ -329,7 +347,7 @@ NiFpga_Status NiFpga_ReadArrayDbl(NiFpga_Session session, uint32_t indicator, do
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteArrayBool(NiFpga_Session session, uint32_t control, const NiFpga_Bool * array, size_t size) {
+NiFpga_Status NiFpgaDll_WriteArrayBool(NiFpga_Session session, uint32_t control, const NiFpga_Bool * array, int size) {
 	printf("NiFpga_WriteArrayBool");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -338,7 +356,7 @@ NiFpga_Status NiFpga_WriteArrayBool(NiFpga_Session session, uint32_t control, co
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteArrayI8(NiFpga_Session session, uint32_t control, const int8_t * array, size_t size) {
+NiFpga_Status NiFpgaDll_WriteArrayI8(NiFpga_Session session, uint32_t control, const int8_t * array, int size) {
 	printf("NiFpga_WriteArrayI8");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -347,7 +365,7 @@ NiFpga_Status NiFpga_WriteArrayI8(NiFpga_Session session, uint32_t control, cons
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteArrayU8(NiFpga_Session session, uint32_t control, const uint8_t * array, size_t size) {
+NiFpga_Status NiFpgaDll_WriteArrayU8(NiFpga_Session session, uint32_t control, const uint8_t * array, int size) {
 	printf("NiFpga_WriteArrayU8");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -356,7 +374,7 @@ NiFpga_Status NiFpga_WriteArrayU8(NiFpga_Session session, uint32_t control, cons
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteArrayI16(NiFpga_Session session, uint32_t control, const int16_t * array, size_t size) {
+NiFpga_Status NiFpgaDll_WriteArrayI16(NiFpga_Session session, uint32_t control, const int16_t * array, int size) {
 	printf("NiFpga_WriteArrayI16");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -365,7 +383,7 @@ NiFpga_Status NiFpga_WriteArrayI16(NiFpga_Session session, uint32_t control, con
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteArrayU16(NiFpga_Session session, uint32_t control, const uint16_t * array, size_t size) {
+NiFpga_Status NiFpgaDll_WriteArrayU16(NiFpga_Session session, uint32_t control, const uint16_t * array, int size) {
 	printf("NiFpga_WriteArrayU16");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -374,7 +392,7 @@ NiFpga_Status NiFpga_WriteArrayU16(NiFpga_Session session, uint32_t control, con
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteArrayI32(NiFpga_Session session, uint32_t control, const int32_t * array, size_t size) {
+NiFpga_Status NiFpgaDll_WriteArrayI32(NiFpga_Session session, uint32_t control, const int32_t * array, int size) {
 	printf("NiFpga_WriteArrayI32");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -383,7 +401,7 @@ NiFpga_Status NiFpga_WriteArrayI32(NiFpga_Session session, uint32_t control, con
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteArrayU32(NiFpga_Session session, uint32_t control, const uint32_t * array, size_t size) {
+NiFpga_Status NiFpgaDll_WriteArrayU32(NiFpga_Session session, uint32_t control, const uint32_t * array, int size) {
 	printf("NiFpga_WriteArrayU32");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -392,7 +410,7 @@ NiFpga_Status NiFpga_WriteArrayU32(NiFpga_Session session, uint32_t control, con
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteArrayI64(NiFpga_Session session, uint32_t control, const int64_t * array, size_t size) {
+NiFpga_Status NiFpgaDll_WriteArrayI64(NiFpga_Session session, uint32_t control, const int64_t * array, int size) {
 	printf("NiFpga_WriteArrayI64");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -401,7 +419,7 @@ NiFpga_Status NiFpga_WriteArrayI64(NiFpga_Session session, uint32_t control, con
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteArrayU64(NiFpga_Session session, uint32_t control, const uint64_t * array, size_t size) {
+NiFpga_Status NiFpgaDll_WriteArrayU64(NiFpga_Session session, uint32_t control, const uint64_t * array, int size) {
 	printf("NiFpga_WriteArrayU64");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -410,7 +428,7 @@ NiFpga_Status NiFpga_WriteArrayU64(NiFpga_Session session, uint32_t control, con
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteArraySgl(NiFpga_Session session, uint32_t control, const float * array, size_t size) {
+NiFpga_Status NiFpgaDll_WriteArraySgl(NiFpga_Session session, uint32_t control, const float * array, int size) {
 	printf("NiFpga_WriteArraySgl");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -419,7 +437,7 @@ NiFpga_Status NiFpga_WriteArraySgl(NiFpga_Session session, uint32_t control, con
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteArrayDbl(NiFpga_Session session, uint32_t control, const double * array, size_t size) {
+NiFpga_Status NiFpgaDll_WriteArrayDbl(NiFpga_Session session, uint32_t control, const double * array, int size) {
 	printf("NiFpga_WriteArrayDbl");
 	printf("\tsession = %d", session);
 	printf("\tcontrol = %d", control);
@@ -428,21 +446,21 @@ NiFpga_Status NiFpga_WriteArrayDbl(NiFpga_Session session, uint32_t control, con
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReserveIrqContext(NiFpga_Session session, NiFpga_IrqContext * context) {
+NiFpga_Status NiFpgaDll_ReserveIrqContext(NiFpga_Session session, NiFpga_IrqContext * context) {
 	printf("NiFpga_ReserveIrqContext");
 	printf("\tsession = %d", session);
 	printf("\tcontext = %p", context);
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_UnreserveIrqContext(NiFpga_Session session, NiFpga_IrqContext context) {
+NiFpga_Status NiFpgaDll_UnreserveIrqContext(NiFpga_Session session, NiFpga_IrqContext context) {
 	printf("NiFpga_UnreserveIrqContext");
 	printf("\tsession = %d", session);
 	printf("\tcontext = %d", context);
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WaitOnIrqs(NiFpga_Session session, NiFpga_IrqContext context, uint32_t irqs, uint32_t timeout, uint32_t * irqsAsserted, NiFpga_Bool * timedOut) {
+NiFpga_Status NiFpgaDll_WaitOnIrqs(NiFpga_Session session, NiFpga_IrqContext context, uint32_t irqs, uint32_t timeout, uint32_t * irqsAsserted, NiFpga_Bool * timedOut) {
 	printf("NiFpga_WaitOnIrqs");
 	printf("\tsession = %d", session);
 	printf("\tcontext = %d", context);
@@ -453,14 +471,14 @@ NiFpga_Status NiFpga_WaitOnIrqs(NiFpga_Session session, NiFpga_IrqContext contex
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcknowledgeIrqs(NiFpga_Session session, uint32_t irqs) {
+NiFpga_Status NiFpgaDll_AcknowledgeIrqs(NiFpga_Session session, uint32_t irqs) {
 	printf("NiFpga_AcknowledgeIrqs");
 	printf("\tsession = %d", session);
 	printf("\tirqs = %d", irqs);
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ConfigureFifo(NiFpga_Session session, uint32_t fifo, size_t depth) {
+NiFpga_Status NiFpgaDll_ConfigureFifo(NiFpga_Session session, uint32_t fifo, int depth) {
 	printf("NiFpga_ConfigureFifo");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -468,7 +486,7 @@ NiFpga_Status NiFpga_ConfigureFifo(NiFpga_Session session, uint32_t fifo, size_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ConfigureFifo2(NiFpga_Session session, uint32_t fifo, size_t requestedDepth, size_t * actualDepth) {
+NiFpga_Status NiFpgaDll_ConfigureFifo2(NiFpga_Session session, uint32_t fifo, int requestedDepth, int * actualDepth) {
 	printf("NiFpga_ConfigureFifo2");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -477,21 +495,21 @@ NiFpga_Status NiFpga_ConfigureFifo2(NiFpga_Session session, uint32_t fifo, size_
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_StartFifo(NiFpga_Session session, uint32_t fifo) {
+NiFpga_Status NiFpgaDll_StartFifo(NiFpga_Session session, uint32_t fifo) {
 	printf("NiFpga_StartFifo");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_StopFifo(NiFpga_Session session, uint32_t fifo) {
+NiFpga_Status NiFpgaDll_StopFifo(NiFpga_Session session, uint32_t fifo) {
 	printf("NiFpga_StopFifo");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadFifoBool(NiFpga_Session session, uint32_t fifo, NiFpga_Bool * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_ReadFifoBool(NiFpga_Session session, uint32_t fifo, NiFpga_Bool * data, int numberOfElements, uint32_t timeout, int * elementsRemaining) {
 	printf("NiFpga_ReadFifoBool");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -502,7 +520,7 @@ NiFpga_Status NiFpga_ReadFifoBool(NiFpga_Session session, uint32_t fifo, NiFpga_
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadFifoI8(NiFpga_Session session, uint32_t fifo, int8_t * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_ReadFifoI8(NiFpga_Session session, uint32_t fifo, int8_t * data, int numberOfElements, uint32_t timeout, int * elementsRemaining) {
 	printf("NiFpga_ReadFifoI8");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -513,7 +531,7 @@ NiFpga_Status NiFpga_ReadFifoI8(NiFpga_Session session, uint32_t fifo, int8_t * 
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadFifoU8(NiFpga_Session session, uint32_t fifo, uint8_t * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_ReadFifoU8(NiFpga_Session session, uint32_t fifo, uint8_t * data, int numberOfElements, uint32_t timeout, int * elementsRemaining) {
 	printf("NiFpga_ReadFifoU8");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -524,7 +542,7 @@ NiFpga_Status NiFpga_ReadFifoU8(NiFpga_Session session, uint32_t fifo, uint8_t *
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadFifoI16(NiFpga_Session session, uint32_t fifo, int16_t * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_ReadFifoI16(NiFpga_Session session, uint32_t fifo, int16_t * data, int numberOfElements, uint32_t timeout, int * elementsRemaining) {
 	printf("NiFpga_ReadFifoI16");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -535,7 +553,7 @@ NiFpga_Status NiFpga_ReadFifoI16(NiFpga_Session session, uint32_t fifo, int16_t 
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadFifoU16(NiFpga_Session session, uint32_t fifo, uint16_t * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_ReadFifoU16(NiFpga_Session session, uint32_t fifo, uint16_t * data, int numberOfElements, uint32_t timeout, int * elementsRemaining) {
 	printf("NiFpga_ReadFifoU16");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -546,7 +564,7 @@ NiFpga_Status NiFpga_ReadFifoU16(NiFpga_Session session, uint32_t fifo, uint16_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadFifoI32(NiFpga_Session session, uint32_t fifo, int32_t * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_ReadFifoI32(NiFpga_Session session, uint32_t fifo, int32_t * data, int numberOfElements, uint32_t timeout, int * elementsRemaining) {
 	printf("NiFpga_ReadFifoI32");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -557,7 +575,7 @@ NiFpga_Status NiFpga_ReadFifoI32(NiFpga_Session session, uint32_t fifo, int32_t 
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadFifoU32(NiFpga_Session session, uint32_t fifo, uint32_t * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_ReadFifoU32(NiFpga_Session session, uint32_t fifo, uint32_t * data, int numberOfElements, uint32_t timeout, int * elementsRemaining) {
 	printf("NiFpga_ReadFifoU32");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -568,7 +586,7 @@ NiFpga_Status NiFpga_ReadFifoU32(NiFpga_Session session, uint32_t fifo, uint32_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadFifoI64(NiFpga_Session session, uint32_t fifo, int64_t * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_ReadFifoI64(NiFpga_Session session, uint32_t fifo, int64_t * data, int numberOfElements, uint32_t timeout, int * elementsRemaining) {
 	printf("NiFpga_ReadFifoI64");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -579,7 +597,7 @@ NiFpga_Status NiFpga_ReadFifoI64(NiFpga_Session session, uint32_t fifo, int64_t 
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadFifoU64(NiFpga_Session session, uint32_t fifo, uint64_t * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_ReadFifoU64(NiFpga_Session session, uint32_t fifo, uint64_t * data, int numberOfElements, uint32_t timeout, int * elementsRemaining) {
 	printf("NiFpga_ReadFifoU64");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -590,7 +608,7 @@ NiFpga_Status NiFpga_ReadFifoU64(NiFpga_Session session, uint32_t fifo, uint64_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadFifoSgl(NiFpga_Session session, uint32_t fifo, float * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_ReadFifoSgl(NiFpga_Session session, uint32_t fifo, float * data, int numberOfElements, uint32_t timeout, int * elementsRemaining) {
 	printf("NiFpga_ReadFifoSgl");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -601,7 +619,7 @@ NiFpga_Status NiFpga_ReadFifoSgl(NiFpga_Session session, uint32_t fifo, float * 
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReadFifoDbl(NiFpga_Session session, uint32_t fifo, double * data, size_t numberOfElements, uint32_t timeout, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_ReadFifoDbl(NiFpga_Session session, uint32_t fifo, double * data, int numberOfElements, uint32_t timeout, int * elementsRemaining) {
 	printf("NiFpga_ReadFifoDbl");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -612,7 +630,7 @@ NiFpga_Status NiFpga_ReadFifoDbl(NiFpga_Session session, uint32_t fifo, double *
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteFifoBool(NiFpga_Session session, uint32_t fifo, const NiFpga_Bool * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+NiFpga_Status NiFpgaDll_WriteFifoBool(NiFpga_Session session, uint32_t fifo, const NiFpga_Bool * data, int numberOfElements, uint32_t timeout, int * emptyElementsRemaining) {
 	printf("NiFpga_WriteFifoBool");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -623,7 +641,7 @@ NiFpga_Status NiFpga_WriteFifoBool(NiFpga_Session session, uint32_t fifo, const 
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteFifoI8(NiFpga_Session session, uint32_t fifo, const int8_t * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+NiFpga_Status NiFpgaDll_WriteFifoI8(NiFpga_Session session, uint32_t fifo, const int8_t * data, int numberOfElements, uint32_t timeout, int * emptyElementsRemaining) {
 	printf("NiFpga_WriteFifoI8");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -634,7 +652,7 @@ NiFpga_Status NiFpga_WriteFifoI8(NiFpga_Session session, uint32_t fifo, const in
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteFifoU8(NiFpga_Session session, uint32_t fifo, const uint8_t * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+NiFpga_Status NiFpgaDll_WriteFifoU8(NiFpga_Session session, uint32_t fifo, const uint8_t * data, int numberOfElements, uint32_t timeout, int * emptyElementsRemaining) {
 	printf("NiFpga_WriteFifoU8");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -645,7 +663,7 @@ NiFpga_Status NiFpga_WriteFifoU8(NiFpga_Session session, uint32_t fifo, const ui
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteFifoI16(NiFpga_Session session, uint32_t fifo, const int16_t * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+NiFpga_Status NiFpgaDll_WriteFifoI16(NiFpga_Session session, uint32_t fifo, const int16_t * data, int numberOfElements, uint32_t timeout, int * emptyElementsRemaining) {
 	printf("NiFpga_WriteFifoI16");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -656,7 +674,7 @@ NiFpga_Status NiFpga_WriteFifoI16(NiFpga_Session session, uint32_t fifo, const i
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteFifoU16(NiFpga_Session session, uint32_t fifo, const uint16_t * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+NiFpga_Status NiFpgaDll_WriteFifoU16(NiFpga_Session session, uint32_t fifo, const uint16_t * data, int numberOfElements, uint32_t timeout, int * emptyElementsRemaining) {
 	printf("NiFpga_WriteFifoU16");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -667,7 +685,7 @@ NiFpga_Status NiFpga_WriteFifoU16(NiFpga_Session session, uint32_t fifo, const u
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteFifoI32(NiFpga_Session session, uint32_t fifo, const int32_t * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+NiFpga_Status NiFpgaDll_WriteFifoI32(NiFpga_Session session, uint32_t fifo, const int32_t * data, int numberOfElements, uint32_t timeout, int * emptyElementsRemaining) {
 	printf("NiFpga_WriteFifoI32");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -678,7 +696,7 @@ NiFpga_Status NiFpga_WriteFifoI32(NiFpga_Session session, uint32_t fifo, const i
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteFifoU32(NiFpga_Session session, uint32_t fifo, const uint32_t * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+NiFpga_Status NiFpgaDll_WriteFifoU32(NiFpga_Session session, uint32_t fifo, const uint32_t * data, int numberOfElements, uint32_t timeout, int * emptyElementsRemaining) {
 	printf("NiFpga_WriteFifoU32");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -689,7 +707,7 @@ NiFpga_Status NiFpga_WriteFifoU32(NiFpga_Session session, uint32_t fifo, const u
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteFifoI64(NiFpga_Session session, uint32_t fifo, const int64_t * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+NiFpga_Status NiFpgaDll_WriteFifoI64(NiFpga_Session session, uint32_t fifo, const int64_t * data, int numberOfElements, uint32_t timeout, int * emptyElementsRemaining) {
 	printf("NiFpga_WriteFifoI64");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -700,7 +718,7 @@ NiFpga_Status NiFpga_WriteFifoI64(NiFpga_Session session, uint32_t fifo, const i
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteFifoU64(NiFpga_Session session, uint32_t fifo, const uint64_t * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+NiFpga_Status NiFpgaDll_WriteFifoU64(NiFpga_Session session, uint32_t fifo, const uint64_t * data, int numberOfElements, uint32_t timeout, int * emptyElementsRemaining) {
 	printf("NiFpga_WriteFifoU64");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -711,7 +729,7 @@ NiFpga_Status NiFpga_WriteFifoU64(NiFpga_Session session, uint32_t fifo, const u
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteFifoSgl(NiFpga_Session session, uint32_t fifo, const float * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+NiFpga_Status NiFpgaDll_WriteFifoSgl(NiFpga_Session session, uint32_t fifo, const float * data, int numberOfElements, uint32_t timeout, int * emptyElementsRemaining) {
 	printf("NiFpga_WriteFifoSgl");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -722,7 +740,7 @@ NiFpga_Status NiFpga_WriteFifoSgl(NiFpga_Session session, uint32_t fifo, const f
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_WriteFifoDbl(NiFpga_Session session, uint32_t fifo, const double * data, size_t numberOfElements, uint32_t timeout, size_t * emptyElementsRemaining) {
+NiFpga_Status NiFpgaDll_WriteFifoDbl(NiFpga_Session session, uint32_t fifo, const double * data, int numberOfElements, uint32_t timeout, int * emptyElementsRemaining) {
 	printf("NiFpga_WriteFifoDbl");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -733,7 +751,7 @@ NiFpga_Status NiFpga_WriteFifoDbl(NiFpga_Session session, uint32_t fifo, const d
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoReadElementsBool(NiFpga_Session session, uint32_t fifo, NiFpga_Bool ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoReadElementsBool(NiFpga_Session session, uint32_t fifo, NiFpga_Bool ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoReadElementsBool");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -745,7 +763,7 @@ NiFpga_Status NiFpga_AcquireFifoReadElementsBool(NiFpga_Session session, uint32_
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoReadElementsI8(NiFpga_Session session, uint32_t fifo, int8_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoReadElementsI8(NiFpga_Session session, uint32_t fifo, int8_t ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoReadElementsI8");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -757,7 +775,7 @@ NiFpga_Status NiFpga_AcquireFifoReadElementsI8(NiFpga_Session session, uint32_t 
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoReadElementsU8(NiFpga_Session session, uint32_t fifo, uint8_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoReadElementsU8(NiFpga_Session session, uint32_t fifo, uint8_t ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoReadElementsU8");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -769,7 +787,7 @@ NiFpga_Status NiFpga_AcquireFifoReadElementsU8(NiFpga_Session session, uint32_t 
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoReadElementsI16(NiFpga_Session session, uint32_t fifo, int16_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoReadElementsI16(NiFpga_Session session, uint32_t fifo, int16_t ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoReadElementsI16");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -781,7 +799,7 @@ NiFpga_Status NiFpga_AcquireFifoReadElementsI16(NiFpga_Session session, uint32_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoReadElementsU16(NiFpga_Session session, uint32_t fifo, uint16_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoReadElementsU16(NiFpga_Session session, uint32_t fifo, uint16_t ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoReadElementsU16");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -793,7 +811,7 @@ NiFpga_Status NiFpga_AcquireFifoReadElementsU16(NiFpga_Session session, uint32_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoReadElementsI32(NiFpga_Session session, uint32_t fifo, int32_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoReadElementsI32(NiFpga_Session session, uint32_t fifo, int32_t ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoReadElementsI32");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -805,7 +823,7 @@ NiFpga_Status NiFpga_AcquireFifoReadElementsI32(NiFpga_Session session, uint32_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoReadElementsU32(NiFpga_Session session, uint32_t fifo, uint32_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoReadElementsU32(NiFpga_Session session, uint32_t fifo, uint32_t ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoReadElementsU32");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -817,7 +835,7 @@ NiFpga_Status NiFpga_AcquireFifoReadElementsU32(NiFpga_Session session, uint32_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoReadElementsI64(NiFpga_Session session, uint32_t fifo, int64_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoReadElementsI64(NiFpga_Session session, uint32_t fifo, int64_t ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoReadElementsI64");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -829,7 +847,7 @@ NiFpga_Status NiFpga_AcquireFifoReadElementsI64(NiFpga_Session session, uint32_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoReadElementsU64(NiFpga_Session session, uint32_t fifo, uint64_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoReadElementsU64(NiFpga_Session session, uint32_t fifo, uint64_t ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoReadElementsU64");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -841,7 +859,7 @@ NiFpga_Status NiFpga_AcquireFifoReadElementsU64(NiFpga_Session session, uint32_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoReadElementsSgl(NiFpga_Session session, uint32_t fifo, float ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoReadElementsSgl(NiFpga_Session session, uint32_t fifo, float ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoReadElementsSgl");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -853,7 +871,7 @@ NiFpga_Status NiFpga_AcquireFifoReadElementsSgl(NiFpga_Session session, uint32_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoReadElementsDbl(NiFpga_Session session, uint32_t fifo, double ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoReadElementsDbl(NiFpga_Session session, uint32_t fifo, double ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoReadElementsDbl");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -865,7 +883,7 @@ NiFpga_Status NiFpga_AcquireFifoReadElementsDbl(NiFpga_Session session, uint32_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoWriteElementsBool(NiFpga_Session session, uint32_t fifo, NiFpga_Bool ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoWriteElementsBool(NiFpga_Session session, uint32_t fifo, NiFpga_Bool ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoWriteElementsBool");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -877,7 +895,7 @@ NiFpga_Status NiFpga_AcquireFifoWriteElementsBool(NiFpga_Session session, uint32
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoWriteElementsI8(NiFpga_Session session, uint32_t fifo, int8_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoWriteElementsI8(NiFpga_Session session, uint32_t fifo, int8_t ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoWriteElementsI8");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -889,7 +907,7 @@ NiFpga_Status NiFpga_AcquireFifoWriteElementsI8(NiFpga_Session session, uint32_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoWriteElementsU8(NiFpga_Session session, uint32_t fifo, uint8_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoWriteElementsU8(NiFpga_Session session, uint32_t fifo, uint8_t ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoWriteElementsU8");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -901,7 +919,7 @@ NiFpga_Status NiFpga_AcquireFifoWriteElementsU8(NiFpga_Session session, uint32_t
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoWriteElementsI16(NiFpga_Session session, uint32_t fifo, int16_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoWriteElementsI16(NiFpga_Session session, uint32_t fifo, int16_t ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoWriteElementsI16");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -913,7 +931,7 @@ NiFpga_Status NiFpga_AcquireFifoWriteElementsI16(NiFpga_Session session, uint32_
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoWriteElementsU16(NiFpga_Session session, uint32_t fifo, uint16_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoWriteElementsU16(NiFpga_Session session, uint32_t fifo, uint16_t ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoWriteElementsU16");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -925,7 +943,7 @@ NiFpga_Status NiFpga_AcquireFifoWriteElementsU16(NiFpga_Session session, uint32_
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoWriteElementsI32(NiFpga_Session session, uint32_t fifo, int32_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoWriteElementsI32(NiFpga_Session session, uint32_t fifo, int32_t ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoWriteElementsI32");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -937,7 +955,7 @@ NiFpga_Status NiFpga_AcquireFifoWriteElementsI32(NiFpga_Session session, uint32_
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoWriteElementsU32(NiFpga_Session session, uint32_t fifo, uint32_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoWriteElementsU32(NiFpga_Session session, uint32_t fifo, uint32_t ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoWriteElementsU32");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -949,7 +967,7 @@ NiFpga_Status NiFpga_AcquireFifoWriteElementsU32(NiFpga_Session session, uint32_
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoWriteElementsI64(NiFpga_Session session, uint32_t fifo, int64_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoWriteElementsI64(NiFpga_Session session, uint32_t fifo, int64_t ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoWriteElementsI64");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -961,7 +979,7 @@ NiFpga_Status NiFpga_AcquireFifoWriteElementsI64(NiFpga_Session session, uint32_
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoWriteElementsU64(NiFpga_Session session, uint32_t fifo, uint64_t ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoWriteElementsU64(NiFpga_Session session, uint32_t fifo, uint64_t ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoWriteElementsU64");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -973,7 +991,7 @@ NiFpga_Status NiFpga_AcquireFifoWriteElementsU64(NiFpga_Session session, uint32_
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoWriteElementsSgl(NiFpga_Session session, uint32_t fifo, float ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoWriteElementsSgl(NiFpga_Session session, uint32_t fifo, float ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoWriteElementsSgl");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -985,7 +1003,7 @@ NiFpga_Status NiFpga_AcquireFifoWriteElementsSgl(NiFpga_Session session, uint32_
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_AcquireFifoWriteElementsDbl(NiFpga_Session session, uint32_t fifo, double ** elements, size_t elementsRequested, uint32_t timeout, size_t * elementsAcquired, size_t * elementsRemaining) {
+NiFpga_Status NiFpgaDll_AcquireFifoWriteElementsDbl(NiFpga_Session session, uint32_t fifo, double ** elements, int elementsRequested, uint32_t timeout, int * elementsAcquired, int * elementsRemaining) {
 	printf("NiFpga_AcquireFifoWriteElementsDbl");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -997,7 +1015,7 @@ NiFpga_Status NiFpga_AcquireFifoWriteElementsDbl(NiFpga_Session session, uint32_
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_ReleaseFifoElements(NiFpga_Session session, uint32_t fifo, size_t elements) {
+NiFpga_Status NiFpgaDll_ReleaseFifoElements(NiFpga_Session session, uint32_t fifo, int elements) {
 	printf("NiFpga_ReleaseFifoElements");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -1005,7 +1023,7 @@ NiFpga_Status NiFpga_ReleaseFifoElements(NiFpga_Session session, uint32_t fifo, 
 	return NiFpga_Status_Success;
 }
 
-NiFpga_Status NiFpga_GetPeerToPeerFifoEndpoint(NiFpga_Session session, uint32_t fifo, uint32_t * endpoint) {
+NiFpga_Status NiFpgaDll_GetPeerToPeerFifoEndpoint(NiFpga_Session session, uint32_t fifo, uint32_t * endpoint) {
 	printf("NiFpga_GetPeerToPeerFifoEndpoint");
 	printf("\tsession = %d", session);
 	printf("\tfifo = %d", fifo);
@@ -1013,3 +1031,10 @@ NiFpga_Status NiFpga_GetPeerToPeerFifoEndpoint(NiFpga_Session session, uint32_t 
 	return NiFpga_Status_Success;
 }
 
+NiFpga_Status NiFpgaDll_GetBitfileContents() {
+    return NiFpga_Status_Success;
+}
+
+NiFpga_Status NiFpgaDll_ClientFunctionCall() {
+    return NiFpga_Status_Success;
+}

--- a/nifpga_shim/generate.py
+++ b/nifpga_shim/generate.py
@@ -14,7 +14,7 @@ def format_type(ty):
 def gen_func(func):
     sig = ""
     sig += func.result_type.spelling + ' '
-    sig += func.spelling
+    sig += func.spelling.replace('NiFpga', 'NiFpgaDll')
     sig += '('
     
     body = ""

--- a/nifpga_shim/generate.py
+++ b/nifpga_shim/generate.py
@@ -1,0 +1,40 @@
+from clang import cindex
+
+index = cindex.Index.create()
+tu = index.parse('./NiFpga.h')
+
+def format_type(ty):
+    if '*' in ty:
+        return "%p"
+    elif 'float' in ty or 'double' in ty:
+        return "%f"
+    else:
+        return "%d"
+
+def gen_func(func):
+    sig = ""
+    sig += func.result_type.spelling + ' '
+    sig += func.spelling
+    sig += '('
+    
+    body = ""
+    body += f'\tprintf("{ func.spelling }");\n'
+
+    for arg in func.get_arguments():
+        sig += arg.type.spelling + ' '
+        sig += arg.spelling + ', '
+
+        body += f'\tprintf("\\t{ arg.spelling } = { format_type(arg.type.spelling) }", { arg.spelling });\n'
+    sig += ') {'
+    body += '\treturn NiFpga_Status_Success;\n'
+    body += '}'
+    print(sig)
+    print(body)
+    print("")
+
+functions = filter(lambda x: x.kind == cindex.CursorKind.FUNCTION_DECL, tu.cursor.get_children())
+
+print('#include "NiFpga.h"\n')
+
+for func in functions:
+    gen_func(func)


### PR DESCRIPTION
This PR adds support for using the real National Instruments FPGA as an acquisition source. It also modifies the public API to expose the raw underlying NiFpga session object, in order to pass it to Matlab to be properly initialized.

It also adds the `aoldaq_flag_nifpga_initialized` and `aoldaq_flag_nifpga_not_initialized` functions to coordinate the aforementioned initialization process.

Also related to #2.